### PR TITLE
Add: Firewall rules module - handle objects

### DIFF
--- a/basics/vpc_firewall/stable/main.tf
+++ b/basics/vpc_firewall/stable/main.tf
@@ -1,21 +1,56 @@
 # Custom Firewall
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall
-resource "google_compute_firewall" "allow-rule-network" {
-  name          = var.fwr_name 
-  network       = var.fwr_network
-  source_ranges = var.fwr_source_range
-  direction     = var.fwr_direction
-  project       = var.gcp_project_id
+# https://github.com/terraform-google-modules/terraform-google-network/tree/master/modules/firewall-rules
 
-  # Enable INGRESS
-  allow {
-    protocol    = var.fwr_protocol
-    ports       = var.fwr_ports
+resource "google_compute_firewall" "rules" {
+  # Iterate through the list of objects
+  for_each                = { for r in var.fwr_rules : r.fwr_name => r }
+
+  # General properties
+  network                 = var.fwr_network
+  project                 = var.gcp_project_id
+
+  # List of objects
+  name                    = each.value.fwr_name
+  description             = each.value.fwr_description
+  direction               = each.value.fwr_direction
+  source_ranges           = each.value.fwr_direction == "INGRESS" ? each.value.fwr_source_ranges : null
+  destination_ranges      = each.value.fwr_direction == "EGRESS" ? each.value.fwr_source_ranges : null
+  source_tags             = each.value.fwr_source_tags
+  source_service_accounts = each.value.fwr_source_service_accounts
+  target_tags             = each.value.fwr_target_tags
+  target_service_accounts = each.value.fwr_target_service_accounts
+  priority                = each.value.fwr_priority
+
+  # Process the list of objects
+  dynamic "allow" {
+    for_each = lookup(each.value, "allow", [])
+    content {
+      protocol = allow.value.protocol
+      ports    = lookup(allow.value, "ports", null)
+    }
   }
-
-  # Apply the rule to target_tags
-  # source_tags = ["lab-vm"]
-  # target_tags = ["lab-vm"]
-
-  # depends_on = [google_compute_network.dev_network]
 }
+
+# Custom Firewall
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall
+#  resource "google_compute_firewall" "allow-rule-network" {
+#    name          = var.fwr_name 
+#    network       = var.fwr_network
+#    source_ranges = var.fwr_source_range
+#    direction     = var.fwr_direction
+#    project       = var.gcp_project_id
+#  
+#    # Enable INGRESS
+#    allow {
+#      protocol    = var.fwr_protocol
+#      ports       = var.fwr_ports
+#    }
+#  
+#    # Apply the rule to target_tags
+#    # source_tags = ["lab-vm"]
+#    # target_tags = ["lab-vm"]
+#  
+#    # depends_on = [google_compute_network.dev_network]
+#  }
+

--- a/basics/vpc_firewall/stable/variables.tf
+++ b/basics/vpc_firewall/stable/variables.tf
@@ -29,6 +29,33 @@ variable "gcp_zone" {
 ## Custom variable definitions
 ## --------------------------------------------------------------
 
+variable "fwr_rules" {
+  description = "List of custom rule definitions (refer to variables file for syntax)."
+  default     = []
+  type = list(object({
+    fwr_name                    = string
+    fwr_description             = string
+    fwr_direction               = string
+    fwr_priority                = number
+    fwr_source_ranges                  = list(string)
+    fwr_source_tags             = list(string)
+    fwr_source_service_accounts = list(string)
+    fwr_target_tags             = list(string)
+    fwr_target_service_accounts = list(string)
+    allow = list(object({
+      protocol = string
+      ports    = list(string)
+    }))
+    deny = list(object({
+      protocol = string
+      ports    = list(string)
+    }))
+    log_config = object({
+      metadata = string
+    })
+  }))
+}
+
 # Default value passed in
 variable "fwr_name" {
   type        = string


### PR DESCRIPTION
Add processing similar to [Cloud Foundation Toolkit](https://github.com/terraform-google-modules) Firewall module:

- [x] [Cloud Foundation Toolkit Firewall Module](https://github.com/terraform-google-modules/terraform-google-network/tree/master/modules/firewall-rules)
- [x] Better integration where multiple rules required
- [x] Tested against existing modules
- [x] Supports default and custom networks