### PR TITLE
Tlf maintenance

### DIFF
--- a/basics/gce_instance/stable/main.tf
+++ b/basics/gce_instance/stable/main.tf
@@ -19,7 +19,7 @@ resource "google_compute_instance" "gce_virtual_machine" {
 
   network_interface {
     #network = var.gce_machine_network
-    #subnetwork = var.gce_machine_network
+    subnetwork = var.gce_machine_network
 
     access_config {
       // Ephemeral IP

--- a/basics/gce_instance/stable/main.tf
+++ b/basics/gce_instance/stable/main.tf
@@ -18,8 +18,8 @@ resource "google_compute_instance" "gce_virtual_machine" {
   }
 
   network_interface {
-    #network = var.gce_machine_network
-    subnetwork = var.gce_machine_network
+    network = var.gce_machine_network == "default" ? var.gce_machine_network : null
+    subnetwork = var.gce_machine_network == "default" ? null : var.gce_machine_network
 
     access_config {
       // Ephemeral IP

--- a/basics/gce_instance/stable/main.tf
+++ b/basics/gce_instance/stable/main.tf
@@ -19,7 +19,7 @@ resource "google_compute_instance" "gce_virtual_machine" {
 
   network_interface {
     #network = var.gce_machine_network
-    subnetwork = var.gce_machine_network
+    #subnetwork = var.gce_machine_network
 
     access_config {
       // Ephemeral IP

--- a/basics/gce_instance/stable/main.tf
+++ b/basics/gce_instance/stable/main.tf
@@ -4,21 +4,22 @@
 
 resource "google_compute_instance" "gce_virtual_machine" {
 
-  name         = "${var.gce_name}"
-  machine_type = "${var.gce_machine_type}"
-  zone         = "${var.gcp_zone}"
+  name         = var.gce_name
+  machine_type = var.gce_machine_type
+  zone         = var.gcp_zone
+  project      = var.gcp_project_id
 
-  tags = "${var.gce_tags}"
+  tags = var.gce_tags
 
   boot_disk {
     initialize_params {
-      image = "${var.gce_machine_image}"
+      image = var.gce_machine_image
     }
   }
 
   network_interface {
-    #network = "${var.gce_machine_network}"
-    subnetwork = "${var.gce_machine_network}"
+    #network = var.gce_machine_network
+    subnetwork = var.gce_machine_network
 
     access_config {
       // Ephemeral IP
@@ -36,6 +37,6 @@ resource "google_compute_instance" "gce_virtual_machine" {
   service_account {
     # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
     # email  = google_service_account.default.email
-    scopes = "${var.gce_scopes}"
+    scopes = var.gce_scopes
   }
 }

--- a/basics/vpc_connector/example/README.md
+++ b/basics/vpc_connector/example/README.md
@@ -1,0 +1,48 @@
+# Terraform: Serverless VPC Access Connector 
+
+## Example
+
+The example is based on the following hierarchy:
+
+```
+.
+├── instructions
+│   ├── en.md
+│   └── img
+├── QL_OWNER
+├── qwiklabs.yaml
+└── tf
+    ├── main.tf
+    ├── outputs.tf
+    ├── runtime.yaml
+    └── variables.tf
+```
+
+__NOTE:__ The Terraform examples assume a configuration sub-directory 
+named `tf` is present.
+
+## Qwiklabs Yaml
+
+#### Custom Properties
+
+```
+1  - type: gcp_project
+2    id: project_0
+3    variant: gcpd
+4    ssh_key_user: user_0
+5    startup_script:
+6      type: qwiklabs
+7      path: tf
+```
+
+#### Visible Outputs
+
+```
+ 1  student_visible_outputs:
+ 2    - label: "Open Google Console"
+ 3      reference: project_0.console_url
+ 4    - label: "GCP Username"
+ 5      reference: user_0.username
+ 6    - label: "GCP Password"
+ 7      reference: user_0.password
+```

--- a/basics/vpc_connector/example/main.tf
+++ b/basics/vpc_connector/example/main.tf
@@ -1,0 +1,23 @@
+# Reference:
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vpc_access_connector
+
+module "la_serverless_vpc_access" {
+  ## NOTE: When changing the source parameter, `terraform init` is required
+
+  ## REMOTE: GitHub (Public) access - working
+  source = "github.com/CloudVLab/terraform-lab-foundation//basics/vpc_connector/stable"
+
+  # Pass values to the module
+  gcp_project_id = var.gcp_project_id
+  gcp_region     = var.gcp_region
+  gcp_zone       = var.gcp_zone
+
+  # Customise the GCS instance
+  sva_name                   = "ideconn"
+  sva_network                = module.la_vpc.vpc_network_name
+  sva_subnet_cidr            = "10.8.0.0/28"
+  sva_connector_machine_type = "f1-micro"
+ 
+  ## Depends on Network
+  depends_on = [ module.la_vpc ]
+}

--- a/basics/vpc_connector/example/outputs.tf
+++ b/basics/vpc_connector/example/outputs.tf
@@ -1,0 +1,11 @@
+## Expose GCE properties
+
+# Terraform Output values
+output "gce_external_ip" {
+  value = module.la_gce.gce_external_ip
+}
+
+output "gce_instance_name" {
+  value = module.la_gce.gce_instance_name
+}
+

--- a/basics/vpc_connector/example/runtime.yaml
+++ b/basics/vpc_connector/example/runtime.yaml
@@ -1,0 +1,2 @@
+runtime: terraform
+version: 1.0.1

--- a/basics/vpc_connector/example/scripts/lab-init
+++ b/basics/vpc_connector/example/scripts/lab-init
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Mandatory Prefix
+echo "STARTUP-SCRIPT START"
+echo "DO_SOMETHING_HERE"
+# Mandatory Postfix
+echo "STARTUP-SCRIPT END"

--- a/basics/vpc_connector/example/variables.tf
+++ b/basics/vpc_connector/example/variables.tf
@@ -1,0 +1,56 @@
+## --------------------------------------------------------------
+## Mandatory variable definitions
+## --------------------------------------------------------------
+
+variable "gcp_project_id" {
+  type        = string
+  description = "The GCP project ID to create resources in."
+}
+
+# Default value passed in
+variable "gcp_region" {
+  type        = string
+  description = "Region to create resources in."
+}
+
+# Default value passed in
+variable "gcp_zone" {
+  type        = string
+  description = "Zone to create resources in."
+}
+
+## --------------------------------------------------------------
+## Output variable definitions - Override from Custom Properties 
+## --------------------------------------------------------------
+
+## --------------------------------------------------------------
+## Custom variable definitions
+## --------------------------------------------------------------
+
+# Default value passed in
+variable "sva_name" {
+  type        = string
+  description = "Name of the VPC connector."
+  default     = "ideconn" 
+}
+
+# Default value passed in
+variable "sva_network" {
+  type        = string
+  description = "Name of the VPC network to use."
+  default     = "default" 
+}
+
+# Default value passed in
+variable "sva_subnet_cidr" {
+  type        = string
+  description = "VPC subnetwork to cidr."
+  default     = "10.8.0.0/28" 
+}
+
+# Default value passed in
+variable "sva_connector_machine_type" {
+  type        = string
+  description = "VPC connector machine default."
+  default     = "f1-micro" 
+}

--- a/basics/vpc_firewall/example/README.md
+++ b/basics/vpc_firewall/example/README.md
@@ -1,0 +1,48 @@
+# Terraform: Firewall 
+
+## Example
+
+The example is based on the following hierarchy:
+
+```
+.
+├── instructions
+│   ├── en.md
+│   └── img
+├── QL_OWNER
+├── qwiklabs.yaml
+└── tf
+    ├── main.tf
+    ├── outputs.tf
+    ├── runtime.yaml
+    └── variables.tf
+```
+
+__NOTE:__ The Terraform examples assume a configuration sub-directory 
+named `tf` is present.
+
+## Qwiklabs Yaml
+
+#### Custom Properties
+
+```
+1  - type: gcp_project
+2    id: project_0
+3    variant: gcpd
+4    ssh_key_user: user_0
+5    startup_script:
+6      type: qwiklabs
+7      path: tf
+```
+
+#### Visible Outputs
+
+```
+ 1  student_visible_outputs:
+ 2    - label: "Open Google Console"
+ 3      reference: project_0.console_url
+ 4    - label: "GCP Username"
+ 5      reference: user_0.username
+ 6    - label: "GCP Password"
+ 7      reference: user_0.password
+```

--- a/basics/vpc_firewall/example/main.tf
+++ b/basics/vpc_firewall/example/main.tf
@@ -1,0 +1,94 @@
+# Reference:
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall
+# https://github.com/terraform-google-modules/terraform-google-network/tree/master/modules/firewall-rules
+
+module "la_fw" {
+  ## NOTE: When changing the source parameter, `terraform init` is required
+
+  ## REMOTE: GitHub (Public) access - working 
+  source = "github.com/CloudVLab/terraform-lab-foundation//basics/vpc_firewall/stable"
+
+  # Pass values to the module
+  gcp_project_id = var.gcp_project_id
+  gcp_region     = var.gcp_region
+  gcp_zone       = var.gcp_zone
+
+  ## Ex: Default Network
+  # fwr_network      = "default" 
+  ## Ex: Custom Network
+  fwr_network      = module.la_vpc.vpc_network_name
+
+  # Firewall Policy - Repeatable list of objects
+  fwr_rules = [
+  {
+    fwr_name                    = "serverless-to-vpc-connector"
+    fwr_description             = "serverless-to-vpc-connector"
+    fwr_source_ranges           = [ "107.178.230.64/26", "35.199.224.0/19" ]
+    fwr_destination_ranges      = null
+    fwr_source_tags             = null
+    fwr_source_service_accounts = null
+    fwr_target_tags             = ["vpc-connector"]
+    fwr_target_service_accounts = null
+    fwr_priority                = "1000"
+    fwr_direction               = "INGRESS"
+
+    # Allow List
+    allow = [{
+      protocol     = "icmp"
+      ports        = null 
+    },
+    {
+      protocol     = "tcp"
+      ports        = [ "667" ]
+    },
+    {
+      protocol     = "udp"
+      ports        = [ "665-666" ]
+    }]
+
+    # Deny List
+    deny = []
+
+    log_config = {
+      metadata = "INCLUDE_ALL_METADATA"
+    }
+
+  },
+  {
+    fwr_name                    = "vpc-connector-egress"
+    fwr_description             = "vpc-connector-egress"
+    fwr_source_ranges           = null 
+    fwr_destination_ranges      = null
+    fwr_source_tags             = [ "vpc-connector" ] 
+    fwr_source_service_accounts = null
+    fwr_target_tags             = null 
+    fwr_target_service_accounts = null
+    fwr_priority                = "1000"
+    fwr_direction               = "INGRESS"
+
+    # Allow List
+    allow = [{
+      protocol     = "tcp"
+      ports        = null 
+    },
+    {
+      protocol     = "udp"
+      ports        = null 
+    },
+    {
+      protocol     = "icmp"
+      ports        = null 
+    }]
+
+    # Deny List
+    deny = []
+
+    log_config = {
+      metadata = "INCLUDE_ALL_METADATA"
+    }
+  }
+  ]
+
+  ## Firewall depends on existence of Network
+  depends_on = [ module.la_vpc.vpc_network_name ]
+}

--- a/basics/vpc_firewall/example/outputs.tf
+++ b/basics/vpc_firewall/example/outputs.tf
@@ -1,0 +1,11 @@
+## Expose GCE properties
+
+# Terraform Output values
+output "gce_external_ip" {
+  value = module.la_gce.gce_external_ip
+}
+
+output "gce_instance_name" {
+  value = module.la_gce.gce_instance_name
+}
+

--- a/basics/vpc_firewall/example/runtime.yaml
+++ b/basics/vpc_firewall/example/runtime.yaml
@@ -1,0 +1,2 @@
+runtime: terraform
+version: 1.0.1

--- a/basics/vpc_firewall/example/scripts/lab-init
+++ b/basics/vpc_firewall/example/scripts/lab-init
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Mandatory Prefix
+echo "STARTUP-SCRIPT START"
+echo "DO_SOMETHING_HERE"
+# Mandatory Postfix
+echo "STARTUP-SCRIPT END"

--- a/basics/vpc_firewall/example/variables.tf
+++ b/basics/vpc_firewall/example/variables.tf
@@ -1,0 +1,64 @@
+## --------------------------------------------------------------
+## Mandatory variable definitions
+## --------------------------------------------------------------
+
+variable "gcp_project_id" {
+  type        = string
+  description = "The GCP project ID to create resources in."
+}
+
+# Default value passed in
+variable "gcp_region" {
+  type        = string
+  description = "Region to create resources in."
+}
+
+# Default value passed in
+variable "gcp_zone" {
+  type        = string
+  description = "Zone to create resources in."
+}
+
+## --------------------------------------------------------------
+## Output variable definitions - Override from Custom Properties 
+## --------------------------------------------------------------
+
+
+
+## --------------------------------------------------------------
+## Custom variable definitions
+## --------------------------------------------------------------
+
+# Default value passed in
+variable "fwr_network" {
+  type        = string
+  description = "Custom VPC network."
+  default     = "default" 
+}
+
+variable "fwr_rules" {
+  description = "List of custom rule definitions (refer to variables file for syntax)."
+  default     = []
+  type = list(object({
+    fwr_name                    = string
+    fwr_description             = string
+    fwr_direction               = string
+    fwr_priority                = number
+    fwr_source_ranges                  = list(string)
+    fwr_source_tags             = list(string)
+    fwr_source_service_accounts = list(string)
+    fwr_target_tags             = list(string)
+    fwr_target_service_accounts = list(string)
+    allow = list(object({
+      protocol = string
+      ports    = list(string)
+    }))
+    deny = list(object({
+      protocol = string
+      ports    = list(string)
+    }))
+    log_config = object({
+      metadata = string
+    })
+  }))
+}

--- a/basics/vpc_network/example/README.md
+++ b/basics/vpc_network/example/README.md
@@ -1,0 +1,48 @@
+# Terraform: VPC  
+
+## Example
+
+The example is based on the following hierarchy:
+
+```
+.
+├── instructions
+│   ├── en.md
+│   └── img
+├── QL_OWNER
+├── qwiklabs.yaml
+└── tf
+    ├── main.tf
+    ├── outputs.tf
+    ├── runtime.yaml
+    └── variables.tf
+```
+
+__NOTE:__ The Terraform examples assume a configuration sub-directory 
+named `tf` is present.
+
+## Qwiklabs Yaml
+
+#### Custom Properties
+
+```
+1  - type: gcp_project
+2    id: project_0
+3    variant: gcpd
+4    ssh_key_user: user_0
+5    startup_script:
+6      type: qwiklabs
+7      path: tf
+```
+
+#### Visible Outputs
+
+```
+ 1  student_visible_outputs:
+ 2    - label: "Open Google Console"
+ 3      reference: project_0.console_url
+ 4    - label: "GCP Username"
+ 5      reference: user_0.username
+ 6    - label: "GCP Password"
+ 7      reference: user_0.password
+```

--- a/basics/vpc_network/example/main.tf
+++ b/basics/vpc_network/example/main.tf
@@ -1,0 +1,26 @@
+# Module: Virtual Private Cloud
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork
+
+module "la_vpc" {
+  ## NOTE: When changing the source parameter, `terraform init` is required
+
+  ## Local Modules - working
+  ## Module subdirectory needs to be defined within the TF directory
+  # source = "./basics/vpc_network/stable"
+
+  ## REMOTE: GitHub (Public) access - working
+  source = "github.com/CloudVLab/terraform-lab-foundation//basics/vpc_network/stable"
+
+  # Pass values to the module
+  gcp_project_id = var.gcp_project_id
+  gcp_region     = var.gcp_region
+  gcp_zone       = var.gcp_zone
+
+  # Customise the GCS instance
+  vpc_network             = "dev-network"
+  vpc_network_description = "Developer network"
+  vpc_subnet              = "dev-subnetwork"
+  vpc_region              = "us-central1"
+  vpc_subnet_cidr         = "10.128.0.0/16"
+}

--- a/basics/vpc_network/example/outputs.tf
+++ b/basics/vpc_network/example/outputs.tf
@@ -1,0 +1,11 @@
+## Expose GCE properties
+
+# Terraform Output values
+output "gce_external_ip" {
+  value = module.la_gce.gce_external_ip
+}
+
+output "gce_instance_name" {
+  value = module.la_gce.gce_instance_name
+}
+

--- a/basics/vpc_network/example/runtime.yaml
+++ b/basics/vpc_network/example/runtime.yaml
@@ -1,0 +1,2 @@
+runtime: terraform
+version: 1.0.1

--- a/basics/vpc_network/example/variables.tf
+++ b/basics/vpc_network/example/variables.tf
@@ -1,0 +1,64 @@
+## --------------------------------------------------------------
+## Mandatory variable definitions
+## --------------------------------------------------------------
+
+variable "gcp_project_id" {
+  type        = string
+  description = "The GCP project ID to create resources in."
+}
+
+# Default value passed in
+variable "gcp_region" {
+  type        = string
+  description = "Region to create resources in."
+}
+
+# Default value passed in
+variable "gcp_zone" {
+  type        = string
+  description = "Zone to create resources in."
+}
+
+## --------------------------------------------------------------
+## Output variable definitions - Override from Custom Properties 
+## --------------------------------------------------------------
+
+
+## --------------------------------------------------------------
+## Custom variable definitions
+## --------------------------------------------------------------
+
+# Default value passed in
+variable "vpc_network" {
+  type        = string
+  description = "Name of the VPC network to create."
+  default     = "dev_network" 
+}
+
+# Default value passed in
+variable "vpc_network_description" {
+  type        = string
+  description = "Custom VPC network."
+  default     = "Qwiklabs lab network" 
+}
+
+# Default value passed in
+variable "vpc_subnet" {
+  type        = string
+  description = "Name of the VPC subnetwork to create."
+  default     = "dev_subnet" 
+}
+
+# Default value passed in
+variable "vpc_region" {
+  type        = string
+  description = "Name of the VPC subnetwork to create."
+  default     = "us-central1" 
+}
+
+# Default value passed in
+variable "vpc_subnet_cidr" {
+  type        = string
+  description = "VPC subnetwork to cidr."
+  default     = "10.128.0.0/16" 
+}


### PR DESCRIPTION
Fix general network assignment.
- [x] network value will only be assigned if `default` is used
- [x] subnetwork value will only be assigned if `default` name is not used

## Example Code:

```
  network_interface {
    network = var.gce_machine_network == "default" ? var.gce_machine_network : null
    subnetwork = var.gce_machine_network == "default" ? null : var.gce_machine_network

    access_config {
      // Ephemeral IP
    }
  }
```
## Synopsis
The above enables the GCE module to use the correct configuration based on the assumption that the `default` network is the one provided by Google Cloud.

If the network/subnet name is changed, the assumption is the network is a custom network!