### PR TITLE
remove vm-name var from readme

### DIFF
--- a/solutions/ide_web/README.md
+++ b/solutions/ide_web/README.md
@@ -10,7 +10,6 @@ __NOTE:__ Qwiklabs requires some values to be defined as part of the provisionin
 gcp_project_id  = "my-gcp-project"
 gcp_region      = "us-central1"
 gcp_zone        = "us-central1-a"
-vm_name         = "tester-vm"
 gcp_username    = "name@domain.com"
 gceMachineImage = "web-codeserver"
 ```


### PR DESCRIPTION
Receive errors when trying to assign the vm-name variable. It looks like it's not used anymore?