### PR TITLE
Add: example VM database configuration

### DIFF
--- a/solutions/appsheet_cloudsql/README.md
+++ b/solutions/appsheet_cloudsql/README.md
@@ -7,6 +7,8 @@
 
 Create a Cloud SQL MySQL instance based on a Terraform configuration
 The Cloud SQL instance has authorized networks for use with AppSheet.
+A VM is used to populate a Cloud SQL database.
+The configuration for the database is specified in the `scripts` folder.
 
 ## Using Input Values 
 
@@ -21,7 +23,7 @@ gcp_region           = "us-central1"
 gcp_zone             = "us-central1-a"
 ```
 
-#### Custom Properties
+#### Custom CloudSQL Properties
 
 ```bash
 sql_user_name     = "lab_tester"
@@ -31,7 +33,31 @@ sql_user_host     = "%"
 sql_user_password = "Password01" 
 ```
 
-__NOTE:__ Database is prefixed with the `project_id` to ensure they are globally unique.
+__NOTE:__ 
+* Database is prefixed with the `project_id` to ensure they are globally unique.
+* Ensure `sql_user_name` and `sql_user_password` are consistent in vm script configuration.
+
+#### Custom VM Properties
+
+If you require a database to be loaded, add the following configuration to preload a schema from Cloud Storage.
+The VM include a basic bash script to authorize and load a custom configuration onto the Cloud SQL instance.
+
+
+```bash
+gce_name          = "mysql_admin"
+gce_tags          = ["lab_vm"]
+gce_machine_image = "debian-cloud/debian-10"
+gce_machine_network = "default"
+gce_scopes          = ["cloud-platform"]
+gce_startup_script  = "${file("./scripts/lab-init")}" 
+```
+
+__NOTE:__ 
+* The GCE instance is created post the Cloud SQL instance
+* The GCE instance will communicate to Cloud SQL using the specified username and password (ensure these are correct in the script)
+* The Cloud SQL authorized network will be reset by the GCE instance to include the GCE External IP
+* The database to be loaded is specified in a public storage bucket within the script
+
 
 ## Accessing Output Values 
 

--- a/solutions/appsheet_cloudsql/example/main.tf
+++ b/solutions/appsheet_cloudsql/example/main.tf
@@ -1,4 +1,24 @@
 # Module: Google CloudSQL 
+module "la_gce" {
+  source = "github.com/CloudVLab/terraform-lab-foundation//basics/gce_instance/stable"
+
+  # Pass values to the module
+  gcp_project_id = var.gcp_project_id
+  gcp_region     = var.gcp_region
+  gcp_zone       = var.gcp_zone
+
+  # Customise the GCE instance
+  gce_name            = "mysql-admin"
+  gce_tags            = ["lab-vm"]
+  gce_machine_image   = "debian-cloud/debian-10"
+  gce_machine_network = "default"
+  gce_scopes          = ["cloud-platform"]
+  gce_startup_script  = "${file("./scripts/lab-init")}"
+
+  # Create the CloudSQL instance
+  depends_on = [ module.la_cloudsql]
+}
+
 module "la_cloudsql" {
   ## NOTE: When changing the source parameter, `terraform init` is required
 

--- a/solutions/appsheet_cloudsql/example/scripts/lab-init
+++ b/solutions/appsheet_cloudsql/example/scripts/lab-init
@@ -1,0 +1,41 @@
+#!/bin/sh
+## https://www.shellcheck.net/
+echo "STARTUP-SCRIPT START"
+sudo apt-get update
+sudo apt-get install -y default-mysql-server
+
+SQL_USER="db_user"
+export SQL_USER
+
+SQL_PASSWORD="Password01"
+export SQL_PASSWORD
+
+# SQL_URL="gs://spls/test-database/"
+SQL_URL="gs://cloud-training/OCBL343/"
+export SQL_URL
+
+# SQL_FILENAME="mysqlsampledatabase.sql"
+SQL_FILENAME="create_mysql_schema.sql"
+export SQL_FILENAME
+
+SQL_SOURCE="$SQL_URL$SQL_FILENAME"
+export SQL_SOURCE
+
+# Download the test database
+gsutil cp "$SQL_SOURCE" /tmp
+
+# Get the instance external IP
+MYSQL_IP="$(gcloud compute instances list --format="value(EXTERNAL_IP)")"
+export MYSQL_IP
+
+# Add the instance external IP to the authorized network
+echo "Y" | gcloud sql instances patch mysql --authorized-networks="$MYSQL_IP"/32,34.87.131.237/32,35.245.209.204/32,35.203.191.15/32,35.247.56.116/32,35.240.247.148/32,34.87.159.166/32,34.87.233.115/32,35.244.107.184/32,35.204.102.20/32,35.204.159.159/32,35.239.203.99/32,34.87.103.64/32,35.239.112.17/32,34.86.96.199/32,35.245.229.252/32,34.83.247.7/32,35.247.40.210/32,35.197.185.203/32,35.244.126.141/32,35.204.213.55/32,34.91.161.74/32,35.222.253.144/32,34.71.7.214/32,35.194.89.186/32
+
+# Get the MySQL Public IP
+DATABASE_IP="$(gcloud sql instances describe mysql --format="value(ipAddresses.ipAddress)")"
+export DATABASE_IP
+
+# Connect to the database + load source
+mysql -h "$DATABASE_IP" -u "$SQL_USER" -p"$SQL_PASSWORD" < /tmp/"$SQL_FILENAME"
+
+echo "STARTUP-SCRIPT END"


### PR DESCRIPTION
Updated AppSheet + Cloud SQL configuration

- [x] Include VM instance loaded with MySQL client
- [x] Add VM external IP to Cloud SQL authorized networks
- [x] Download database schema from remote bucket
- [x] Install new database