### PR TITLE
Add: null value for gke autopilot false state

### DIFF
--- a/solutions/ide_gke_developer/dev/main.tf
+++ b/solutions/ide_gke_developer/dev/main.tf
@@ -287,7 +287,7 @@ resource "google_container_cluster" "dev_cluster" {
   enable_binary_authorization = var.gkeIsBinAuth == true ? var.gkeIsBinAuth : false 
 
   # Condition setting to variable. If defined set to variable, default to false
-  enable_autopilot            = var.gkeIsAutopilot == true ? var.gkeIsAutopilot : false 
+  enable_autopilot            = var.gkeIsAutopilot == true ? var.gkeIsAutopilot : null 
 
   private_cluster_config {
     enable_private_endpoint = var.gkeIsPrivateEndpoint 


### PR DESCRIPTION
Amend GKE Autopilot set to false. Using NULL to indicate the property should use the default state.

Ref: [Terraform Types](https://www.terraform.io/language/expressions/types#types)