### PR TITLE
Gce instance

### DIFF
--- a/basics/gce_instance/README.md
+++ b/basics/gce_instance/README.md
@@ -26,9 +26,12 @@ gce_tags            = ["lab-vm"]
 gce_machine_image   = "debian-cloud/debian-10" 
 gce_machine_network = "default"
 gce_scopes          = ["cloud-platform"]
+gce_service_account = "default"
 gce_startup_script  = "${file("./lab-init")}"
 ```
 __NOTE:__
+- [x] The default service account is compute developer
+- [x] To replace the default use the email of custom SA
 - [x] Naming convention for a startup-script is `lab-init`
 - [x] The startup_script should only be used for short lived tasks
 - [x] Do not use scripts to call other scripts

--- a/basics/gce_instance/example/main.tf
+++ b/basics/gce_instance/example/main.tf
@@ -22,5 +22,6 @@ module "la_gce" {
   gce_machine_network = "default" 
   #gce_machine_network = google_compute_subnetwork.dev_subnet.name
   #gce_scopes          = ["cloud-platform"] 
+  #gce_service_account = "default"
   #gce_startup_script   = "${file("./scripts/lab-init")}"
 }

--- a/basics/gce_instance/stable/main.tf
+++ b/basics/gce_instance/stable/main.tf
@@ -37,6 +37,7 @@ resource "google_compute_instance" "gce_virtual_machine" {
   service_account {
     # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
     # email  = google_service_account.default.email
+    email = var.gce_service_account == "default" ? null : var.gce_service_account
     scopes = var.gce_scopes
   }
 }

--- a/basics/gce_instance/stable/variables.tf
+++ b/basics/gce_instance/stable/variables.tf
@@ -93,6 +93,14 @@ variable "gce_scopes" {
 }
 
 # Custom properties with defaults 
+## The default setting uses compute developer service account
+variable "gce_service_account" {
+  type        = string
+  description = "GCE Service Account"
+  default     = "default" 
+}
+
+# Custom properties with defaults 
 variable "gce_startup_script" {
   type        = string
   description = "GCE startup script"


### PR DESCRIPTION
Add GCE custom service account

- [x] default set to use compute developer SA
- [x] replace the property gce_service_account with custom SA email