### PR TITLE
Add: VPC network as output variable

### DIFF
--- a/solutions/ide_web/stable/outputs.tf
+++ b/solutions/ide_web/stable/outputs.tf
@@ -16,3 +16,8 @@ output "ideInstanceName" {
   value       = "${var.gceInstanceName}"
   description = "Name of the GCE instance"
 }
+
+output "vpcNetworkName" {
+  value       = "${module.la_vpc.vpc_network_name}"
+  description = "Name of the GCE instance"
+}


### PR DESCRIPTION
Expose the network as an output variable. Enable module users to add resources to the custom network used.

```
output "vpcNetworkName" {
  value       = "${module.la_vpc.vpc_network_name}"
  description = "Name of the GCE instance"
}
```