### PR TITLE
Add: location variable

### DIFF
--- a/solutions/ide_cloud_code/dev/main.tf
+++ b/solutions/ide_cloud_code/dev/main.tf
@@ -272,7 +272,7 @@ resource "google_compute_instance" "default" {
 resource "google_container_cluster" "primary" {
   provider    = google-beta
   name        = var.gkeClusterName
-  location    = var.gcp_region
+  location    = var.gkeLocation
   description = "dev cluster for testing"
 
   # Define VPC configuration

--- a/solutions/ide_cloud_code/dev/variables.tf
+++ b/solutions/ide_cloud_code/dev/variables.tf
@@ -124,6 +124,13 @@ variable "gceInstanceScope" {
 ## GKE Settings
 #
 
+# Custom properties with defaults 
+variable "gkeLocation" {
+  type        = string 
+  description = "Regional or Zonal cluster master."
+  default     = "us-central1" 
+}
+
 variable "gkeDescription" {
   type        = string 
   description = "Description to apply to the cluster."


### PR DESCRIPTION
Reference: [container_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster)

- [x] Add location variable to enable the creation of Regional or Zonal clusters.

location - (Optional) The location (region or zone) in which the cluster master will be created, as well as the default node location. If you specify a zone (such as us-central1-a), the cluster will be a zonal cluster with a single cluster master. If you specify a region (such as us-west1), the cluster will be a regional cluster with multiple masters spread across zones in the region, and with default node locations in those zones as well