### PR TITLE
Add: standard variables

### DIFF
--- a/solutions/ide_cloud_code/stable/variables.tf
+++ b/solutions/ide_cloud_code/stable/variables.tf
@@ -28,6 +28,7 @@ variable "gcp_zone" {
 variable "gcp_username" {
   type        = string
   description = "Name of Qwiklabs user"
+  default     = "tester"
 }
 
 ## --------------------------------------------------------------
@@ -70,8 +71,8 @@ variable "gcrRegion" {
 variable "gceMachineImage" {
   type        = string
   description = "GCE virtual machine image family"
-#  default     = "ide-codeserver"
-  default     = "debian-cloud/debian-10"
+  default     = "cloud-code-codeserver"
+#  default     = "debian-cloud/debian-10"
 }
 
 variable "gceProjectMachineImage" {


### PR DESCRIPTION
Add a standard value for the Cloud Code labs.

- [x] username set to `tester` if not passed through from yaml configuration
- [x] default to cloud-code image when machine image not supplied.