### PR TITLE
Fix: workbench proxy vpc connector name gen

### DIFF
--- a/solutions/proxy_vertex_workbench/stable/main.tf
+++ b/solutions/proxy_vertex_workbench/stable/main.tf
@@ -171,7 +171,7 @@ resource "random_string" "vpc-connector" {
 # Enable VPC connector
 resource "google_vpc_access_connector" "connector" {
   ## Max 25 characters
-  name     = "notebookconn-${random_string.vpc-connector.id}"
+  name     = "vpcconn-${random_string.vpc-connector.id}"
   provider = google-beta
   project  = var.gcp_project_id
   region   = var.gcp_region

--- a/solutions/proxy_vertex_workbench/stable/main.tf
+++ b/solutions/proxy_vertex_workbench/stable/main.tf
@@ -163,15 +163,15 @@ resource "google_project_service" "vpcaccess-api" {
 ## https://www.phillipsj.net/posts/random-things-with-terraform/
 ## ^[a-z][-a-z0-9]{0,23}[a-z0-9]$.
 resource "random_string" "vpc-connector" {
-  length    = 16
-  special = false
+  length    = 10
+  special   = false
   upper     = false
 }
 
 # Enable VPC connector
 resource "google_vpc_access_connector" "connector" {
   ## Max 25 characters
-  name     = random_string.vpc-connector.id
+  name     = "notebookconn-${random_string.vpc-connector.id}"
   provider = google-beta
   project  = var.gcp_project_id
   region   = var.gcp_region


### PR DESCRIPTION
Module: Proxy Vertex Workbench
Repo: terraform-lab-foundation/solutions

## Observation:
Sometimes the "google_vpc_access_connector" would fail with the following error: "Connector ID must follow the pattern ^[a-z][-a-z0-9]{0,23}[a-z0-9]"

## Issue:
The randomly generated string resource would sometimes begin with a number and break the specified pattern.

## Fix:
This change ensures the name begins with a letter, something coherent, and has a randomly generated suffix as well.