### PR TITLE
Google Cloud Storage - Amend naming policy

### DIFF
--- a/basics/gcs_bucket/README.md
+++ b/basics/gcs_bucket/README.md
@@ -25,7 +25,7 @@ gcp_zone             = "us-central1-a"
 ```
 gcs_bucket_extension = "my_bucket"
 gcs_append_project   = true
-gcs_storage_class    = "MULTI_REGIONAL"
+gcs_storage_class    = "STANDARD"
 ```
 
 | STORAGE CLASS |

--- a/basics/gcs_bucket/README.md
+++ b/basics/gcs_bucket/README.md
@@ -24,6 +24,7 @@ gcp_zone             = "us-central1-a"
 
 ```
 gcs_bucket_extension = "my_bucket"
+gcs_append_project   = true
 gcs_storage_class    = "MULTI_REGIONAL"
 ```
 
@@ -39,7 +40,13 @@ gcs_storage_class    = "MULTI_REGIONAL"
 
 __NOTE:__ Buckets are prefixed with the `project_id` to ensure they are globally unique.
 
+If you want to override the name of the bucket:
+
+- [x] Set the `gcs_bucket_extension` to the name of the bucket
+- [x] Set the `gcs_append_project` value to false
+
 Ensure the value for the `gcs_bucket_extension` is unique within the project.
+
 
 ## Accessing Output Values 
 

--- a/basics/gcs_bucket/example/main.tf
+++ b/basics/gcs_bucket/example/main.tf
@@ -16,5 +16,6 @@ module "la_gcs" {
 
   # Customise the GCS instance
   gcs_bucket_extension = "bucket" 
-  gcs_storage_class   = "STANDARD"
+  gcs_storage_class    = "STANDARD"
+  gcs_append_project   = true 
 }

--- a/basics/gcs_bucket/stable/main.tf
+++ b/basics/gcs_bucket/stable/main.tf
@@ -3,7 +3,7 @@
 #
 # TODO: Move to building block
 resource "google_storage_bucket" "cloud-bucket" {
-  name                        = gcs_append_bucket ? "${var.gcp_project_id}-${var.gcs_bucket_extension}" : "${var.gcs_bucket_extension}"
+  name                        = var.gcs_append_bucket ? "${var.gcp_project_id}-${var.gcs_bucket_extension}" : "${var.gcs_bucket_extension}"
   location                    = var.gcp_region 
   project                     = var.gcp_project_id
   storage_class               = var.gcs_storage_class

--- a/basics/gcs_bucket/stable/main.tf
+++ b/basics/gcs_bucket/stable/main.tf
@@ -3,11 +3,10 @@
 #
 # TODO: Move to building block
 resource "google_storage_bucket" "cloud-bucket" {
-  name                        = "${var.gcp_project_id}-${var.gcs_bucket_extension}"
+  name                        = gcs_append_bucket ? "${var.gcp_project_id}-${var.gcs_bucket_extension}" : "${var.gcs_bucket_extension}"
   location                    = var.gcp_region 
   project                     = var.gcp_project_id
   storage_class               = var.gcs_storage_class
-
   force_destroy               = true
   uniform_bucket_level_access = true
 }

--- a/basics/gcs_bucket/stable/main.tf
+++ b/basics/gcs_bucket/stable/main.tf
@@ -3,7 +3,7 @@
 #
 # TODO: Move to building block
 resource "google_storage_bucket" "cloud-bucket" {
-  name                        = var.gcs_append_bucket ? "${var.gcp_project_id}-${var.gcs_bucket_extension}" : "${var.gcs_bucket_extension}"
+  name                        = var.gcs_append_project ? "${var.gcp_project_id}-${var.gcs_bucket_extension}" : "${var.gcs_bucket_extension}"
   location                    = var.gcp_region 
   project                     = var.gcp_project_id
   storage_class               = var.gcs_storage_class

--- a/basics/gcs_bucket/stable/variables.tf
+++ b/basics/gcs_bucket/stable/variables.tf
@@ -43,7 +43,7 @@ variable "gcs_storage_class" {
   default     = "MULTI_REGIONAL"
 }
 
-variable "gcs_append_project"
+variable "gcs_append_project" {
   type        = bool
   description = "Append the Project ID to bucket name"
   default     = true

--- a/basics/gcs_bucket/stable/variables.tf
+++ b/basics/gcs_bucket/stable/variables.tf
@@ -42,3 +42,9 @@ variable "gcs_storage_class" {
   description = "GCS Bucket name."
   default     = "MULTI_REGIONAL"
 }
+
+variable "gcs_append_project"
+  type        = bool
+  description = "Append the Project ID to bucket name"
+  default     = true
+}

--- a/basics/gcs_bucket/stable/variables.tf
+++ b/basics/gcs_bucket/stable/variables.tf
@@ -40,7 +40,7 @@ variable "gcs_bucket_extension" {
 variable "gcs_storage_class" {
   type        = string
   description = "GCS Bucket name."
-  default     = "MULTI_REGIONAL"
+  default     = "STANDARD"
 }
 
 variable "gcs_append_project" {


### PR DESCRIPTION
Module: GCS_STORAGE
Folder: Basics

Feedback from content authors to enable project name to be used. Current best practice is to combine the project_id with a bucket name to enable a unique reference. Updated the module so authors can override this with a name of their choosing.

- [x] Updated docs
- [x] Updated example doc
- [x] Update script to use a conditional for choosing which naming policy to use.
- [x] Retained a default of project_id-bucket
- [x] Amended the default storage class to STANDARD