### PR TITLE
Cloud Run: document environment variable support

### DIFF
--- a/basics/cloud_run/example/main.tf
+++ b/basics/cloud_run/example/main.tf
@@ -16,4 +16,5 @@ module "la_automl" {
   #gcrService = "automl-proxy"
   #gcrImage   = "gcr.io/qwiklabs-resources/ide-proxy:latest"
   #gcrRegion  = "us-central1"
+  #gcrEnvs    = [ { "URL", "https://storage.googleapis.com/spl-api/test2.json" } ]
 }


### PR DESCRIPTION
Updated example showing how to override the default __environment variables__

- [x] Add to the env block - requires `name` and `value` field to be completed
- [x] Data structure is a list of objects
- [x] [Cloud Run Terraform docs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service)