### PR TITLE
Add: choice of cluster Zonal/Regional

### DIFF
--- a/basics/gke_standard/README.md
+++ b/basics/gke_standard/README.md
@@ -21,11 +21,17 @@ gcp_zone       = "us-central1-a"
 #### Custom Properties
 
 ```
+gkeLocation      = gke_zone | gke_region
 gkeClusterName   = "tester-gke"
 gkeDescription   = "Lab cluster"
 gkeNetwork       = "default"
 gkeSubnet        = "default"
 ```
+
+
+Note: 
+* gkeLocation: Either zonal (e.g. gcp_zone) or regional (e.g. (gcp_region)
+
 
 ## Accessing Output Values 
 

--- a/basics/gke_standard/example/main.tf
+++ b/basics/gke_standard/example/main.tf
@@ -13,6 +13,7 @@ module "la_gke_std" {
   gcp_zone            = var.gcp_zone
 
   # Customise the GKE cluster 
+  gkeLocation       = gcp_zone 
   gkeClusterName    = "test-cluster"
   gkeDescription    = "Lab Cluster"
   gkeNetwork        = "default"

--- a/basics/gke_standard/stable/main.tf
+++ b/basics/gke_standard/stable/main.tf
@@ -9,12 +9,12 @@
 resource "google_container_cluster" "primary" {
   provider    = google-beta
   name        = var.gkeClusterName
-  location    = var.gcp_region
+  location    = var.gkeLocation
   description = var.gkeDescription 
 
   # Define VPC configuration
-  network    = var.gkeIsCustomNetwork ? var.gkeNetwork : null 
-  subnetwork = var.gkeIsCustomNetwork ? var.gkeSubnetwork : null 
+  network    = var.gkeNetwork 
+  subnetwork = var.gkeSubnetwork 
 
   # Set networking mode
   networking_mode = var.gkeNetworkingMode ? var.gkeModeVpcNative : var.gkeModeRoutes 
@@ -28,6 +28,18 @@ resource "google_container_cluster" "primary" {
   # Condition setting to variable. If defined set to variable, otherwise default to false 
 #  enable_binary_authorization = var.gkeIsBinAuth ? var.gkeIsBinAuth : null 
  
+  node_config {
+    # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
+    service_account = google_service_account.default.email
+    machine_type = var.gkeMachine 
+##    oauth_scopes = [
+##      "https://www.googleapis.com/auth/cloud-platform"
+##    ]
+##    labels = {
+##      foo = "bar"
+##    }
+##    tags = ["foo", "bar"]
+  }
 
   ## NOTE: Set null value where false value is set
   # Condition setting to variable. If defined set to variable, default to false

--- a/basics/gke_standard/stable/variables.tf
+++ b/basics/gke_standard/stable/variables.tf
@@ -42,6 +42,18 @@ variable "gkeDescription" {
   default     = "Lab cluster - using default description" 
 }
 
+variable "gkeLocation" {
+  type        = string 
+  description = "Machine type to use in the cluster."
+  default     = "us-central1-a" 
+}
+
+variable "gkeMachine" {
+  type        = string 
+  description = "Machine type to use in the cluster."
+  default     = "e2-medium" 
+}
+
 variable "gkeIsPrivateCluster" {
   type        = bool
   description = "Set as True to spin up a private, secure cluster. False to spin up a public cluster."


### PR DESCRIPTION
Migrate module to allow choice of cluster

- [x] Regional - set `gkeLocation` to `gcp_region`
- [x] Zonal - set `gkeLocation` to `gcp_zone` (__Default option__)


Ref: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#location
* A zonal cluster will have a single controller applied
* A regional cluster will have multiple controllers applied