### PR TITLE
Add: Startup script handler

### DIFF
--- a/solutions/cloud_code_developer/stable/main.tf
+++ b/solutions/cloud_code_developer/stable/main.tf
@@ -193,11 +193,11 @@ module "la_gce" {
   gce_zone            = var.gcp_zone 
   gce_machine_image   = data.google_compute_image.image_family.self_link
   gce_machine_network = module.la_vpc.vpc_subnetwork_name
+  gce_startup_script  = var.gcp_startup  
 
   ## IDE depends on existence of Network
   depends_on = [ module.la_vpc.vpc_network_name]
 }
-
 
 ## # Module: Google Kubernetes Engine
 ## module "la_gke_standard" {

--- a/solutions/cloud_code_developer/stable/variables.tf
+++ b/solutions/cloud_code_developer/stable/variables.tf
@@ -18,3 +18,10 @@ variable "gcp_zone" {
   type        = string
   description = "Zone to create resources in."
 }
+
+# Default value passed in
+variable "gcp_startup" {
+  type        = string
+  description = "Zone to create resources in."
+  default     = "echo Welcome Cloud Code Developer > /tmp/octopus.txt"
+}


### PR DESCRIPTION
Add the ability to pass startup to cloud code.

- [x] Will write a test file to the /tmp directory by default
- [x] Override the `gce_startup_script` variable to run a custom script