### PR TITLE
Fix: variable definition

### DIFF
--- a/basics/firestore_document/example/main.tf
+++ b/basics/firestore_document/example/main.tf
@@ -14,5 +14,5 @@ module "la_firestore_document" {
   # Customise the Firestore Document
   gfd_collection_id = "mycollection" 
   gfd_document_id   = "mydocument" 
-  gfd_document_data = { default= {"field_1"= {"stringValue"="Test"}} } 
+  gfd_document_data = {"field_1"= {"stringValue"="Test"}}
 }


### PR DESCRIPTION
Amend the example variable definition:

* Pass an object to Firestore Document using JSON. 
* Ensure the field is correctly formatted as shown below:

```
gfd_document_data = {"field_1"= {"stringValue"="Test"}}
```

