### PR TITLE
Fix: Typo Cloud Functions

### DIFF
--- a/basics/cloud_function/example/install.sh
+++ b/basics/cloud_function/example/install.sh
@@ -2,7 +2,7 @@
 
 BRANCH="main"
 TYPE="basics"
-MODULE="cloud_functions"
+MODULE="cloud_function"
 URL="https://storage.googleapis.com/terraform-lab-foundation"
 #URL="https://github.com/CloudVLab/terraform-lab-foundation/raw/${BRANCH}"
 


### PR DESCRIPTION
Rename Cloud Functions to Cloud Function in the installation script.