### PR TITLE
Add: Replace bucket object name

### DIFF
--- a/basics/cloud_function/stable/main.tf
+++ b/basics/cloud_function/stable/main.tf
@@ -37,7 +37,7 @@ resource "google_cloudfunctions_function" "custom_function" {
 
   available_memory_mb   = 128
   source_archive_bucket = google_storage_bucket.bucket.name
-  source_archive_object = google_storage_bucket_object.archive.source
+  source_archive_object = google_storage_bucket_object.archive.name
   ## source_archive_bucket = var.gcf_target_bucket 
   ## source_archive_object = var.gcf_archive_source
   trigger_http          = true


### PR DESCRIPTION
Replace source value with object name.

- [x] Bucket object set to source, meaning not able to access source code
- [x] Replace existing source with name to give access to source code