### PR TITLE
Add: Custom Metadata as a Map

### DIFF
--- a/basics/gce_instance/stable/main.tf
+++ b/basics/gce_instance/stable/main.tf
@@ -28,9 +28,8 @@ resource "google_compute_instance" "gce_virtual_machine" {
   }
 
   # Add Key/Value pair e.g. SSH keys here
-  # metadata = {
-  #  foo = "bar"
-  # }
+  metadata = var.gce_metadata
+
 
   # Override to perform startup script
   metadata_startup_script = var.gce_startup_script 

--- a/basics/gce_instance/stable/variables.tf
+++ b/basics/gce_instance/stable/variables.tf
@@ -101,6 +101,14 @@ variable "gce_service_account" {
 }
 
 # Custom properties with defaults 
+## The default Metadata setting 
+variable "gce_metadata" {
+  type        = map 
+  description = "GCE Metadata object"
+  default     = {"foo" = "bar"} 
+}
+
+# Custom properties with defaults 
 variable "gce_startup_script" {
   type        = string
   description = "GCE startup script"


### PR DESCRIPTION
Module: gce_instance

Enable Metadata configuration within the GCE Instance.

- [x] Required for Apigee Labs that use Metadata to pass information
- [x] Replace hardcoded value with custom variable for user defined metadata