### PR TITLE
Add: Override processing + Default values

### DIFF
--- a/basics/gce_instance/stable/main.tf
+++ b/basics/gce_instance/stable/main.tf
@@ -28,11 +28,11 @@ resource "google_compute_instance" "gce_virtual_machine" {
   }
 
   # Add Key/Value pair e.g. SSH keys here
-  metadata = var.gce_metadata
+  metadata = var.gce_metadata == null ? null : var.gce_metadata
 
 
   # Override to perform startup script
-  metadata_startup_script = var.gce_startup_script 
+  metadata_startup_script = var.gce_startup_script == null ? null : var.gce_startup_script 
 
   service_account {
     # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.

--- a/basics/gce_instance/stable/variables.tf
+++ b/basics/gce_instance/stable/variables.tf
@@ -105,14 +105,14 @@ variable "gce_service_account" {
 variable "gce_metadata" {
   type        = map(string)
   description = "GCE Metadata object"
-  # default     = {"foo" = "bar"} 
+  default     = {"foo" = "bar"} 
 }
 
 # Custom properties with defaults 
 variable "gce_startup_script" {
   type        = string
   description = "GCE startup script"
-  # default     = "echo Welcome to Project Octopus > /tmp/octopus.txt" 
+  default     = "echo Welcome to Project Octopus > /tmp/octopus.txt" 
 }
 
 # Custom properties with defaults 


### PR DESCRIPTION
Add sensible defaults as folks are now starting to use startup scripts + metadata for compute resources.

default(s)

- [x] Startup script set to null if not required
- [x] Metadata set to null if not required