### PR TITLE
add notebook_name as output for vai_notebook_basic module

### DIFF
--- a/basics/vai_notebook/stable/outputs.tf
+++ b/basics/vai_notebook/stable/outputs.tf
@@ -2,6 +2,11 @@
 ## Custom variable defintions
 ## --------------------------------------------------------------
 
+variable "notebook_name" {
+  value        = "${var.vai_notebook_name}"
+  description = "Vertex VM instance name."
+}
+
 # output "gce_instance_name" {
 #   value       = "${var.vm_name}"
 #   description = "Name of the GCE instance"


### PR DESCRIPTION
Accessing the name is helpful for integrating this module with other resources if needed and doesn't affect the existing code.