### PR TITLE
fix: incorrect output definition

### DIFF
--- a/basics/vai_notebook/stable/outputs.tf
+++ b/basics/vai_notebook/stable/outputs.tf
@@ -2,7 +2,7 @@
 ## Custom variable defintions
 ## --------------------------------------------------------------
 
-variable "notebook_name" {
+output "notebook_name" {
   value        = "${var.vai_notebook_name}"
   description = "Vertex VM instance name."
 }


### PR DESCRIPTION
Accidentally left this defined as a variable. Fixing the defintion.