### PR TITLE
GKE Standard: Fix redundant variable

### DIFF
--- a/basics/gke_standard/stable/variables.tf
+++ b/basics/gke_standard/stable/variables.tf
@@ -26,18 +26,18 @@ variable "gcp_zone" {
 ### Retired - please use gkeClusterName instead
 # Expected custom_properties key to be declared in `qwiklabs.yaml` 
 # with the same name for any lab that uses this script.
-variable "gkeClusterName" {
-  type        = string
-  description = "GKE Cluster name."
-  default     = "test-cluster"
-}
-
-# with the same name for any lab that uses this script.
-variable "gcp_username" {
-  type        = string
-  description = "Name of Qwiklabs user"
-  default     = "student"
-}
+## variable "gkeClusterName" {
+##   type        = string
+##   description = "GKE Cluster name."
+##   default     = "test-cluster"
+## }
+## 
+## # with the same name for any lab that uses this script.
+## variable "gcp_username" {
+##   type        = string
+##   description = "Name of Qwiklabs user"
+##   default     = "student"
+## }
 
 
 ## --------------------------------------------------------------


### PR DESCRIPTION
Terraform Lab Foundation
* Module: GKE_Standard

General Lab review using [checklist](https://docs.google.com/document/d/1FE5PYZNUSaNeurFudjOHCmG8x5N7eGT4FgDdOrdKhJs/edit#):


- [x] Remove redundant variable declaration