### PR TITLE
Hotfix: Tlf ide vpc connector

### DIFF
--- a/solutions/ide_cloud_code/dev/main.tf
+++ b/solutions/ide_cloud_code/dev/main.tf
@@ -161,7 +161,8 @@ resource "google_project_service" "run" {
 
 resource "google_cloud_run_service" "ide" {
   name     = var.gcrIDEService
-  location = var.gcrRegion
+  # location = var.gcrRegion
+  location = var.gcp_region
 
   template {
     spec {

--- a/solutions/ide_cloud_code/stable/main.tf
+++ b/solutions/ide_cloud_code/stable/main.tf
@@ -161,7 +161,8 @@ resource "google_project_service" "run" {
 
 resource "google_cloud_run_service" "ide" {
   name     = var.gcrIDEService
-  location = var.gcrRegion
+  # location = var.gcrRegion
+  location = var.gcp_region
 
   template {
     spec {

--- a/solutions/ide_cloudshell/stable/main.tf
+++ b/solutions/ide_cloudshell/stable/main.tf
@@ -186,7 +186,8 @@ resource "google_project_service" "run" {
 # Cloud Run: IDE
 resource "google_cloud_run_service" "ide" {
   name     = "ide-service" 
-  location = var.gcrRegion
+  # location = var.gcrRegion
+  location = var.gcp_region
 
   template {
     spec {
@@ -220,7 +221,8 @@ resource "google_cloud_run_service" "ide" {
 # Cloud Run: Browser 
 resource "google_cloud_run_service" "browser" {
   name     = "browser-service"
-  location = var.gcrRegion
+  # location = var.gcrRegion
+  location = var.gcp_region
 
   template {
     spec {

--- a/solutions/ide_tensorflow/stable/main.tf
+++ b/solutions/ide_tensorflow/stable/main.tf
@@ -186,7 +186,8 @@ resource "google_project_service" "run" {
 # Cloud Run: IDE
 resource "google_cloud_run_service" "ide" {
   name     = "ide-service" 
-  location = var.gcrRegion
+  # location = var.gcrRegion
+  location = var.gcp_region
 
   template {
     spec {
@@ -220,7 +221,8 @@ resource "google_cloud_run_service" "ide" {
 # Cloud Run: Browser 
 resource "google_cloud_run_service" "browser" {
   name     = "browser-service"
-  location = var.gcrRegion
+  # location = var.gcrRegion
+  location = var.gcp_region
 
   template {
     spec {

--- a/solutions/ide_web/dev/main.tf
+++ b/solutions/ide_web/dev/main.tf
@@ -265,7 +265,8 @@ resource "google_project_service" "run" {
 
 resource "google_cloud_run_service" "ide" {
   name     = "ide-service" 
-  location = var.gcrRegion
+  # location = var.gcrRegion
+  location = var.gcp_region
 
   template {
     spec {
@@ -299,7 +300,8 @@ resource "google_cloud_run_service" "ide" {
 
 resource "google_cloud_run_service" "browser" {
   name     = "browser-service"
-  location = var.gcrRegion
+  # location = var.gcrRegion
+  location = var.gcp_region
 
   template {
     spec {

--- a/solutions/ide_web/stable/main.tf
+++ b/solutions/ide_web/stable/main.tf
@@ -265,7 +265,8 @@ resource "google_project_service" "run" {
 
 resource "google_cloud_run_service" "ide" {
   name     = "ide-service" 
-  location = var.gcrRegion
+  # location = var.gcrRegion
+  location = var.gcp_region
 
   template {
     spec {
@@ -299,7 +300,8 @@ resource "google_cloud_run_service" "ide" {
 
 resource "google_cloud_run_service" "browser" {
   name     = "browser-service"
-  location = var.gcrRegion
+  # location = var.gcrRegion
+  location = var.gcp_region
 
   template {
     spec {

--- a/solutions/lab_proxy/dev/main.tf
+++ b/solutions/lab_proxy/dev/main.tf
@@ -47,7 +47,8 @@ resource "google_project_service" "run" {
 
 resource "google_cloud_run_service" "ide" {
   name     = var.gcrServiceName
-  location = var.gcrRegion
+  # location = var.gcrRegion
+  location = var.gcp_region
 
   template {
     spec {

--- a/solutions/proxy_vertex_workbench/dev/main.tf
+++ b/solutions/proxy_vertex_workbench/dev/main.tf
@@ -293,7 +293,8 @@ resource "google_project_service" "run" {
 # Cloud Run: IDE
 resource "google_cloud_run_service" "jupyter" {
   name     = var.gcrServiceName
-  location = var.gcrRegion
+  # location = var.gcrRegion
+  location = var.gcp_region
   project  = var.gcp_project_id
 
   template {

--- a/solutions/proxy_vertex_workbench/stable/main.tf
+++ b/solutions/proxy_vertex_workbench/stable/main.tf
@@ -294,7 +294,8 @@ resource "google_project_service" "run" {
 # Cloud Run: IDE
 resource "google_cloud_run_service" "jupyter" {
   name     = var.gcrServiceName
-  location = var.gcrRegion
+  # location = var.gcrRegion
+  location = var.gcp_region
   project  = var.gcp_project_id
 
   template {


### PR DESCRIPTION
HotFix

Reset region setting. Ensure Cloud Run + VPC Connector are placed in the same region.
Region setting derived from the platform. Set both resources to the same setting to avoid issues.

- [x] Change all instances of gcrRegion to use the var.gpc_region property
- [x] Change impacts stable|beta|dev channels