### PR TITLE
OSL001: FraudFinder installation doc + script

### DIFF
--- a/solutions/fraudfinder/example/README.md
+++ b/solutions/fraudfinder/example/README.md
@@ -18,12 +18,41 @@ The example is based on the following hierarchy:
     └── variables.tf
 ```
 
+## Add the module to the directory 
+
+Add the example Terraform code module to your project
+
+```
+curl -L https://github.com/CloudVLab/terraform-lab-foundation/raw/main/solutions/fraudfinder/example/install.sh | bash
+```
+
+## View the updated directory 
+
+The example is based on the following hierarchy:
+
+```
+.
+├── instructions
+│   ├── en.md
+│   └── img
+├── QL_OWNER
+├── qwiklabs.yaml
+└── tf
+    ├── main.tf
+    ├── outputs.tf
+    ├── runtime.yaml
+    └── variables.tf
+```
+
 __NOTE:__ The Terraform examples assume a configuration sub-directory 
 named `tf` is present.
 
-## Qwiklabs Yaml
+## Update Qwiklabs Yaml
 
 #### Custom Properties
+
+The `qwiklabs.yaml` configuration file is used to set the optional definition of 
+custom properties e.g. `gcp_user_id`:
 
 ```
 1  - type: gcp_project
@@ -33,9 +62,15 @@ named `tf` is present.
 5    startup_script:
 6      type: qwiklabs
 7      path: tf
+8      custom_properties:
+9      - key: gcp_user_id 
+10       reference: user_0.username 
 ```
 
 #### Visible Outputs
+
+The `qwiklabs.yaml` configuration file is used to set the definition of 
+student visible outputs e.g. `GCP Username` 
 
 ```
  1  student_visible_outputs:

--- a/solutions/fraudfinder/example/install.sh
+++ b/solutions/fraudfinder/example/install.sh
@@ -1,16 +1,17 @@
 #!/bin/sh
 BRANCH="main"
-MODULE="fraudfinder"
-TYPE="solutions"
 CHANNEL="STABLE"
+TYPE="solutions"
+MODULE="fraudfinder"
 
 # Set the endpoint for the module
 if [ "$CHANNEL" = "STABLE" ]; then
   ## STABLE Channel
-  URL="https://github.com/CloudVLab/terraform-lab-foundation/raw/${BRANCH}"
+  URL="https://storage.googleapis.com/terraform-lab-foundation/"
+  # URL="https://github.com/CloudVLab/terraform-lab-foundation/raw/${BRANCH}"
 else
   ## DEV/BETA Channel
-  URL="https://raw.githubusercontent.com/CloudVLab/terraform-lab-foundation/${BRANCH}/"
+  URL="https://github.com/CloudVLab/terraform-lab-foundation/raw/${BRANCH}"
 fi 
 
 DIRECTORY="tf"
@@ -25,7 +26,7 @@ FILE4_URL="${URL}/${TYPE}/${MODULE}/example/variables.tf"
 
 # Create TF directory if not present
 if [ ! -d $DIRECTORY ]; then
-    mkdir $DIRECTORY 
+  mkdir $DIRECTORY 
 fi
 
 # Download if the file does not exist


### PR DESCRIPTION
Terraform Lab Foundation
* Module: FraudFinder

General Lab review using [checklist](https://docs.google.com/document/d/1FE5PYZNUSaNeurFudjOHCmG8x5N7eGT4FgDdOrdKhJs/edit#):


- [x] Update README to include installation script example
- [x] Update installations script to use Cloud Storage location