### PR TITLE
GCE Instance: GCE default Boot disk params

### DIFF
--- a/basics/gce_instance/stable/main.tf
+++ b/basics/gce_instance/stable/main.tf
@@ -17,6 +17,8 @@ resource "google_compute_instance" "gce_virtual_machine" {
     device_name = var.gce_name
     initialize_params {
       image = var.gce_machine_image
+      size  = var.gce_disk_size 
+      type  = var.gce_disk_type
     }
   }
 

--- a/basics/gce_instance/stable/variables.tf
+++ b/basics/gce_instance/stable/variables.tf
@@ -78,6 +78,18 @@ variable "gce_machine_image" {
   default     = "debian-cloud/debian-10"
 }
 
+variable "gce_disk_size" {
+  type        = string
+  description = "Boot Disk size"
+  default     = "10GB"
+}
+
+variable "gce_disk_type" {
+  type        = string
+  description = "Boot Disk Type"
+  default     = "pd-standard"
+}
+
 # Custom properties with defaults 
 variable "gce_machine_network" {
   type        = string


### PR DESCRIPTION
Add Boot Disk parameters:

- [x] Boot Disk Size - default `10GB`
- [x] Boot Disk Type - default `pd-standard`