### PR TITLE
GKE Standard: Move block to cluster auto-scale

### DIFF
--- a/basics/gke_standard/stable/main.tf
+++ b/basics/gke_standard/stable/main.tf
@@ -34,6 +34,9 @@ resource "google_container_cluster" "tfer-gke" {
 
   cluster_autoscaling {
     enabled = false
+    auto_provisioning_defaults {
+      image_type = var.gkeImageType 
+    }
   }
 
 
@@ -136,7 +139,4 @@ resource "google_container_cluster" "tfer-gke" {
     workload_pool = "${var.gcp_project_id}.svc.id.goog"
   }
 
-  auto_provisioning_defaults {
-    image_type = var.gkeImageType 
-  }
 }


### PR DESCRIPTION
Amend module to place image type within the cluster auto-scale block.