### PR TITLE
Add: Google Cloud platform default changed to 100GB

### DIFF
--- a/basics/gce_instance/stable/variables.tf
+++ b/basics/gce_instance/stable/variables.tf
@@ -81,7 +81,7 @@ variable "gce_machine_image" {
 variable "gce_disk_size" {
   type        = number 
   description = "Boot Disk size"
-  default     = 10
+  default     = 100
 }
 
 variable "gce_disk_type" {


### PR DESCRIPTION
Terraform Lab Foundation
* Module: GCE Instance
* Buganizer: https://buganizer.corp.google.com/issues/274896557

General Lab review using [checklist](https://docs.google.com/document/d/1FE5PYZNUSaNeurFudjOHCmG8x5N7eGT4FgDdOrdKhJs/edit#):

- [x] Update standard Google Cloud disk size to 100GB