### PR TITLE
IDE Web: IDE_Web/GCE Instance Disk Size property

### DIFF
--- a/solutions/ide_web/example/main.tf
+++ b/solutions/ide_web/example/main.tf
@@ -29,10 +29,11 @@ module "la_ide" {
   gcp_project_id  = var.gcp_project_id 
   gcp_region      = var.gcp_region 
   gcp_zone        = var.gcp_zone 
-  gcp_username    = var.tfUsername
+  # gcp_username    = var.tfUsername
 
   ## Properties: GCE 
   gceMachineImage    = "web-codeserver" 
+  gceDiskSize        = 100 
 
   ## Properties: Cloud Run
   gcrRegion        = var.gcp_region 

--- a/solutions/ide_web/stable/main.tf
+++ b/solutions/ide_web/stable/main.tf
@@ -240,6 +240,7 @@ module "la_gce" {
   #gce_machine_network = module.la_vpc.vpc_network_name
   #gce_machine_network = default 
   gce_scopes          = ["cloud-platform"] 
+  gce_disk_size       = var.gceDiskSize 
   #gce_startup_script   = "${file("./scripts/lab-init")}"
 
   # Dependency - Serverless VPC Access connector 

--- a/solutions/ide_web/stable/variables.tf
+++ b/solutions/ide_web/stable/variables.tf
@@ -83,6 +83,13 @@ variable "gceMachineType" {
 }
 
 # Custom properties with defaults 
+variable "gceDiskSize" {
+  type        = number 
+  description = "Size of disk to be allocated"
+  default     = 100 
+}
+
+# Custom properties with defaults 
 variable "gceInstanceNetwork" {
   type        = string
   description = "GCE virtual machine network"


### PR DESCRIPTION
Terraform Lab Foundation
* Module: IDE_Web

General Lab review using [checklist](https://docs.google.com/document/d/1FE5PYZNUSaNeurFudjOHCmG8x5N7eGT4FgDdOrdKhJs/edit#):

- [x] Expose `gceDiskSize` element to allow custom images to be used with the module
- [x] Pass custom image size to the `gce_instance` module
