### PR TITLE
Module iam_service_account: Initial version

### DIFF
--- a/basics/iam_service_account/README.md
+++ b/basics/iam_service_account/README.md
@@ -1,0 +1,47 @@
+# Terraform: IAM Service Account 
+
+| Channel | Status |
+|---------|--------|
+| Dev     | WIP    | 
+| Stable  | TBC    | 
+
+Create a IAM binding for a role
+
+## Using Input Values 
+
+__NOTE:__ Qwiklabs requires some values to be defined as part of the provisioning process. 
+
+#### Qwiklabs Properties
+```
+gcp_project_id = "my-gcp-project"
+gcp_region     = "us-central1"
+gcp_zone       = "us-central1-a"
+```
+
+#### Custom Properties
+
+```
+iam_sa_name        = "custom-sa" 
+iam_sa_description = "Custom SA" 
+```
+
+## Example
+
+View the [example configuration](https://github.com/CloudVLab/terraform-lab-foundation/tree/main/basics/iam_service_account/example) to get started.
+
+## Accessing Output Values 
+
+| Field | Description |
+|-------|-------------|
+| iam_service_account   | The name of the service created         |
+| iam_service_account_description   | The description of the service created         |
+
+## Adding a Commit 
+
+Commits to the repository will initiate the automated QA process.
+
+It is highly recommended that modules are tested locally before making a commit.
+
+## Request a Pull Request
+
+__DO NOT__ raise a PR on code that does not pass integration tests.

--- a/basics/iam_service_account/cloudbuild.yaml
+++ b/basics/iam_service_account/cloudbuild.yaml
@@ -1,0 +1,21 @@
+steps:
+- name: 'hashicorp/terraform:${_PROVIDER_VER}'
+  args: ['init']
+  id: init-terraform
+  dir: '${_TERRAFORM_DIR}' 
+- name: 'hashicorp/terraform:${_PROVIDER_VER}'
+  args: ['validate']
+  id: validate-terraform
+  dir: '${_TERRAFORM_DIR}' 
+- name: 'hashicorp/terraform:${_PROVIDER_VER}'
+  args: ['apply', '-var-file=test.tfvars', '-auto-approve']
+  id: apply-terraform
+  dir: '${_TERRAFORM_DIR}' 
+- name: 'hashicorp/terraform:${_PROVIDER_VER}'
+  args: ['destroy', '-var-file=test.tfvars', '-auto-approve']
+  id: destroy-terraform
+  dir: '${_TERRAFORM_DIR}' 
+substitutions:  
+  _PROVIDER_VER: 1.0.1
+  _TERRAFORM_DIR: basics/iam_service_account/stable
+tags: ['terraform-lab-foundation','iam', 'service', 'account']  

--- a/basics/iam_service_account/example/README.md
+++ b/basics/iam_service_account/example/README.md
@@ -1,0 +1,68 @@
+# Terraform: IAM Service Account 
+
+## Example
+
+The example is based on the following hierarchy:
+
+```
+.
+├── instructions
+│   ├── en.md
+│   └── img
+├── QL_OWNER
+└── qwiklabs.yaml 
+```
+
+
+
+## Add the module to the directory
+
+Add the example Terraform code module to your project
+```
+curl -L https://github.com/CloudVLab/terraform-lab-foundation/raw/main/basics/iam_service_account/example/install.sh | bash
+```
+
+
+## View the update directory
+
+The example is based on the following heirarchy:
+```
+.
+├── instructions
+│   ├── en.md
+│   └── img
+├── QL_OWNER
+├── qwiklabs.yaml
+└── tf
+    ├── main.tf
+    ├── outputs.tf
+    ├── runtime.yaml
+    └── variables.tf
+```
+
+__NOTE:__ The Terraform examples assume a configuration sub-directory 
+named `tf` is present.
+
+## Qwiklabs Yaml
+
+#### Custom Properties
+
+Add a startup_script section to `qwiklabs.yaml` to run Terraform
+
+```
+1  - type: gcp_project
+2    id: project_0
+3    variant: gcpd
+4    ssh_key_user: user_0
+5    startup_script:
+6      type: qwiklabs
+7      path: tf
+```
+
+The general overrides values are illustrated below:
+
+| Field | Default | Comment |
+|-------|---------|---------|
+| iam_sa_name | custom-sa | Service account name |
+| iam_sa | custom-sa | Service account display name |
+| iam_sa_description  | Customer service account for application | Service account description |

--- a/basics/iam_service_account/example/install.sh
+++ b/basics/iam_service_account/example/install.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+BRANCH="main"
+TYPE="basics"
+MODULE="iam_service_account"
+URL="https://storage.googleapis.com/terraform-lab-foundation"
+#URL="https://github.com/CloudVLab/terraform-lab-foundation/raw/${BRANCH}"
+
+DIRECTORY="tf"
+FILE1="main.tf"
+FILE1_URL="${URL}/${TYPE}/${MODULE}/example/main.tf"
+FILE2="outputs.tf"
+FILE2_URL="${URL}/${TYPE}/${MODULE}/example/outputs.tf"
+FILE3="runtime.yaml"
+FILE3_URL="${URL}/${TYPE}/${MODULE}/example/runtime.yaml"
+FILE4="variables.tf"
+FILE4_URL="${URL}/${TYPE}/${MODULE}/example/variables.tf"
+
+
+# Create TF directory if not present
+if [ ! -d $DIRECTORY ]; then
+  mkdir $DIRECTORY 
+fi
+
+# Download if the file does not exist
+if [ ! -f $DIRECTORY/$FILE1 ]; then
+curl -L $FILE1_URL -o "$DIRECTORY/$FILE1"
+fi 
+
+# Download if the file does not exist
+if [ ! -f $DIRECTORY/$FILE2 ]; then
+curl -L $FILE2_URL -o "$DIRECTORY/$FILE2"
+fi
+
+# Download if the file does not exist
+if [ ! -f $DIRECTORY/$FILE3 ]; then
+curl -L $FILE3_URL -o "$DIRECTORY/$FILE3"
+fi
+
+# Download if the file does not exist
+if [ ! -f $DIRECTORY/$FILE4 ]; then
+curl -L $FILE4_URL -o "$DIRECTORY/$FILE4"
+fi

--- a/basics/iam_service_account/example/main.tf
+++ b/basics/iam_service_account/example/main.tf
@@ -1,0 +1,30 @@
+# Basics: IAM Service Account 
+# Local:  basics/iam_service_account/dev
+# Remote: github//basics/iam_service_account/stable
+
+module "la_sa" {
+  ## NOTE: When changing the `source` parameter
+  ## `terraform init` is required
+
+  ## https://www.terraform.io/language/modules/sources#selecting-a-revision
+  ## Local Modules - working
+  ## Module subdirectory needs to be defined within the TF directory
+  ## source = "./basics/iam_service_account/stable"
+
+  ## REMOTE: GitHub (Public) access - working 
+  ## source = "github.com/CloudVLab/terraform-lab-foundation//basics/iam_service_account/dev?ref=tlf_iam"
+
+  ## REMOTE: GitHub (Public) access - working 
+  source = "github.com/CloudVLab/terraform-lab-foundation//basics/iam_service_account/stable"
+
+  ## Exchange values between Qwiklabs and Module
+  gcp_project_id = var.gcp_project_id
+  gcp_region     = var.gcp_region 
+  gcp_zone       = var.gcp_zone 
+
+  ## Custom Properties
+  # Pass reference to the student username
+  iam_sa_name = "test" 
+  iam_sa_display = "test account" 
+  iam_sa_description = "sa description" 
+}

--- a/basics/iam_service_account/example/outputs.tf
+++ b/basics/iam_service_account/example/outputs.tf
@@ -1,0 +1,8 @@
+## --------------------------------------------------------------
+## Custom variable defintions
+## --------------------------------------------------------------
+
+output "iam_service_account" {
+  value       = "module.la_sa.iam_service_account"
+  description = "Name of the Service Account to be created"
+}

--- a/basics/iam_service_account/example/runtime.yaml
+++ b/basics/iam_service_account/example/runtime.yaml
@@ -1,0 +1,2 @@
+runtime: terraform
+version: 1.0.1

--- a/basics/iam_service_account/example/variables.tf
+++ b/basics/iam_service_account/example/variables.tf
@@ -1,0 +1,19 @@
+#
+# ------------------  Qwiklabs Values
+#
+variable "gcp_project_id" {
+  type = string
+}
+
+variable "gcp_region" {
+  type = string
+}
+
+variable "gcp_zone" {
+  type = string
+}
+
+#
+# ------------------  Custom Properties
+#
+

--- a/basics/iam_service_account/stable/main.tf
+++ b/basics/iam_service_account/stable/main.tf
@@ -1,0 +1,33 @@
+# Reference
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_service_account
+#
+
+resource "google_service_account" "custom_sa" {
+  account_id   = var.iam_sa_name 
+  description  = var.iam_sa_description 
+  display_name = var.iam_sa_display 
+}
+
+## variable "sa_members" {
+##   type = list(string)
+##   default = ["user1@example.com", "user2@example.com", "user3@example.com"]
+## }
+## 
+## variable "sa_roles" {
+##   type = list(string)
+##   default = ["roles/viewer", "roles/editor", "roles/owner"]
+## }
+
+## resource "google_project_iam_member" "tlf" {
+##   for_each = {
+##     for idx, role in var.sa_roles: idx => {
+##       member = var.sa_member
+##       role   = role 
+##     }
+##   }
+## 
+##   project = var.gcp_project_id 
+##   member  = var.sa_member
+##   role    = each.value.role
+## }
+## 

--- a/basics/iam_service_account/stable/outputs.tf
+++ b/basics/iam_service_account/stable/outputs.tf
@@ -1,0 +1,8 @@
+## --------------------------------------------------------------
+## Custom variable defintions
+## --------------------------------------------------------------
+
+output "iam_service_account" {
+  value       = "${google_service_account.custom_sa.account_id}"
+  description = "Name of the Service Account to be created"
+}

--- a/basics/iam_service_account/stable/provider.tf
+++ b/basics/iam_service_account/stable/provider.tf
@@ -1,0 +1,5 @@
+provider "google" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+  zone    = var.gcp_zone
+}

--- a/basics/iam_service_account/stable/runtime.yaml
+++ b/basics/iam_service_account/stable/runtime.yaml
@@ -1,0 +1,2 @@
+runtime: terraform
+version: 1.0.1

--- a/basics/iam_service_account/stable/variables.tf
+++ b/basics/iam_service_account/stable/variables.tf
@@ -1,0 +1,45 @@
+## --------------------------------------------------------------
+## Mandatory variable definitions
+## --------------------------------------------------------------
+
+variable "gcp_project_id" {
+  type        = string
+  description = "The GCP project ID to create resources in."
+}
+
+# Default value passed in
+variable "gcp_region" {
+  type        = string
+  description = "Region to create resources in."
+}
+
+# Default value passed in
+variable "gcp_zone" {
+  type        = string
+  description = "Zone to create resources in."
+}
+
+## --------------------------------------------------------------
+## Variable definitions - Override from Custom Properties 
+## --------------------------------------------------------------
+
+# with the same name for any lab that uses this script.
+variable "iam_sa_name" {
+  type        = string
+  description = "Role to bind to the user account"
+  default     = "tester-qwiklabs" 
+}
+
+# with the same name for any lab that uses this script.
+variable "iam_sa_description" {
+  type        = string
+  description = "Custom Service Account for IAM binding"
+  default     = "Test service account" 
+}
+
+# with the same name for any lab that uses this script.
+variable "iam_sa_display" {
+  type        = string
+  description = "Custom Service Account for IAM binding"
+  default     = "test" 
+}


### PR DESCRIPTION
Terraform Lab Foundation
* Module: iam_service_account

Separate the creation of an IAM account into an isolated module.  Use this module in conjunction with role bind to create an account member with associated permissions.

