### PR TITLE
cloudbuild_script: Initial version

### DIFF
--- a/solutions/cloudbuild_script/README.md
+++ b/solutions/cloudbuild_script/README.md
@@ -1,0 +1,39 @@
+# Terraform: Cloud Build Script 
+
+| Channel | Status |
+|---------|--------|
+| Stable  | TBC    | 
+| Beta    | TBC    | 
+
+Invoke Cloud Build based on a Terraform configuration
+
+## Using Input Values 
+
+__NOTE:__ Qwiklabs requires some values to be defined as part of the provisioning process.
+
+#### Qwiklabs Properties
+```
+gcp_project_id           = var.gcp_project_id 
+gcp_region               = var.gcp_region 
+gcp_zone                 = var.gcp_zone 
+service_account_key_file = var.service_account_key_file
+```
+
+#### Custom Properties
+
+Override in `qwiklabs.yaml` file custom_properties stanza.
+
+
+## Accessing Output Values 
+
+N/A
+
+## Adding a Commit 
+
+Commits to the repository will initiate the automated QA process.
+
+It is highly recommended that modules are tested locally before making a commit.
+
+## Request a Pull Request
+
+__DO NOT__ raise a PR on code that does not pass integration tests.

--- a/solutions/cloudbuild_script/cloudbuild.yaml
+++ b/solutions/cloudbuild_script/cloudbuild.yaml
@@ -1,0 +1,22 @@
+steps:
+- name: 'hashicorp/terraform:${_PROVIDER_VER}'
+  args: ['init']
+  id: init-terraform
+  dir: '${_TERRAFORM_DIR}' 
+- name: 'hashicorp/terraform:${_PROVIDER_VER}'
+  args: ['validate']
+  id: validate-terraform
+  dir: '${_TERRAFORM_DIR}' 
+- name: 'hashicorp/terraform:${_PROVIDER_VER}'
+  args: ['apply', '-var-file=test.tfvars', '-auto-approve']
+  id: apply-terraform
+  dir: '${_TERRAFORM_DIR}' 
+- name: 'hashicorp/terraform:${_PROVIDER_VER}'
+  args: ['destroy', '-var-file=test.tfvars', '-auto-approve']
+  id: destroy-terraform
+  dir: '${_TERRAFORM_DIR}' 
+substitutions:  
+  _PROVIDER_VER: 1.0.1
+  _TERRAFORM_DIR: solutions/asm_cluster/stable
+tags: ['terraform-lab-foundation','script', 'cloudbuild']  
+timeout: 1200s

--- a/solutions/cloudbuild_script/example/README.md
+++ b/solutions/cloudbuild_script/example/README.md
@@ -1,0 +1,94 @@
+# Terraform: Cloud Build Script
+
+
+## Example
+
+The example is based on the following hierarchy:
+
+```
+.
+├── instructions
+│   ├── en.md
+│   └── img
+├── QL_OWNER
+└── qwiklabs.yaml 
+```
+
+## Script
+
+Add the example Terraform code module to your project
+```bash
+curl  -L https://github.com/CloudVLab/terraform-lab-foundation/raw/main/solutions/cloudbuild_script/example/install.sh | bash
+```
+
+## Task 1. Example
+
+The script will update the hierarchy:
+
+```
+.
+├── instructions
+│   ├── en.md
+│   └── img
+├── QL_OWNER
+├── qwiklabs.yaml
+└── tf
+    ├── main.tf
+    ├── outputs.tf
+    ├── runtime.yaml
+    └── variables.tf
+```
+
+__NOTE:__ The Terraform examples assume a configuration sub-directory 
+named `tf` is present.
+
+## Qwiklabs Yaml
+
+Update the `qwiklabs.yaml` to include startup_script configuration i.e. Terraform
+
+#### Custom Properties
+
+```
+1  - type: gcp_project
+2    id: project_0
+3    variant: gcpd
+4    ssh_key_user: user_0
+5    startup_script:
+6      type: qwiklabs
+7      path: tf
+```
+
+
+Update the `qwiklabs.yaml` to include visible output returned from the startup_script
+
+#### Visible Outputs
+
+```
+ 1  student_visible_outputs:
+ 2    - label: "Open Google Cloud console"
+ 3      reference: project_0.console_url
+ 4    - label: "GCP Username"
+ 5      reference: user_0.username
+ 6    - label: "GCP Password"
+ 7      reference: user_0.password
+```
+
+
+Add a custom property by referencing the Terrform output variables.
+Append the values to the `student_visible_outputs` section in the `qwiklabs.yaml`
+
+```
+ 1  student_visible_outputs:
+ 2    - label: "Open Google Console"
+ 3      reference: project_0.console_url
+ 4    - label: "GCP Username"
+ 5      reference: user_0.username
+ 6    - label: "GCP Password"
+ 7      reference: user_0.password
+```
+
+#### Dynamic Variables
+
+The output variable can be accessed with the following reference:
+
+N/A

--- a/solutions/cloudbuild_script/example/install.sh
+++ b/solutions/cloudbuild_script/example/install.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+BRANCH="main"
+MODULE="cloudbuild_script"
+TYPE="solutions"
+CHANNEL="STABLE"
+
+# Set the endpoint for the module
+if [ "$CHANNEL" = "STABLE" ]; then
+  ## STABLE Channel
+  URL="https://github.com/CloudVLab/terraform-lab-foundation/raw/${BRANCH}"
+else
+  ## DEV/BETA Channel
+  URL="https://github.com/CloudVLab/terraform-lab-foundation/raw/${BRANCH}"
+fi 
+
+DIRECTORY="tf"
+FILE1="main.tf"
+FILE1_URL="${URL}/${TYPE}/${MODULE}/example/main.tf"
+FILE2="outputs.tf"
+FILE2_URL="${URL}/${TYPE}/${MODULE}/example/outputs.tf"
+FILE3="runtime.yaml"
+FILE3_URL="${URL}/${TYPE}/${MODULE}/example/runtime.yaml"
+FILE4="variables.tf"
+FILE4_URL="${URL}/${TYPE}/${MODULE}/example/variables.tf"
+
+# Create TF directory if not present
+if [ ! -d $DIRECTORY ]; then
+  mkdir $DIRECTORY 
+fi
+
+# Download if the file does not exist
+if [ ! -f $DIRECTORY/$FILE1 ]; then
+curl -L $FILE1_URL -o "$DIRECTORY/$FILE1"
+fi 
+
+# Download if the file does not exist
+if [ ! -f $DIRECTORY/$FILE2 ]; then
+curl -L $FILE2_URL -o "$DIRECTORY/$FILE2"
+fi
+
+# Download if the file does not exist
+if [ ! -f $DIRECTORY/$FILE3 ]; then
+curl -L $FILE3_URL -o "$DIRECTORY/$FILE3"
+fi
+
+# Download if the file does not exist
+if [ ! -f $DIRECTORY/$FILE4 ]; then
+curl -L $FILE4_URL -o "$DIRECTORY/$FILE4"
+fi
+
+
+## ---------------------------------------------------------------------------
+## Scripts Directory
+
+SCRIPTS="tf/scripts"
+SCRIPT="lab-init.sh"
+SCRIPT_URL="${URL}/${TYPE}/${MODULE}/example/scripts/${SCRIPT}"
+
+# Create TF directory if not present
+if [ ! -d "$SCRIPTS" ]; then
+    mkdir -p $SCRIPTS
+fi
+
+# Download if the file does not exist
+if [ ! -f "$SCRIPTS/$SCRIPT" ]; then
+  curl -L $SCRIPT_URL -o "$SCRIPTS/$SCRIPT"
+fi

--- a/solutions/cloudbuild_script/example/main.tf
+++ b/solutions/cloudbuild_script/example/main.tf
@@ -1,0 +1,14 @@
+# Solution: CloudBuild Script 
+# Remote: github.com/CloudVLab/terraform-lab-foundation//solutions/cloudbuild_script/stable
+
+module "cloudbuild_script" {
+  source = "terraform-google-modules/gcloud/google"
+  version = "~> 3.0.1"
+  platform = "linux"
+  create_cmd_entrypoint = "chmod +x ${path.module}/scripts/lab-init.sh;${path.module}/scripts/lab-init.sh"
+  create_cmd_body = "${var.gcp_project_id}"
+  skip_download = false
+  upgrade = false
+  gcloud_sdk_version = "358.0.0"
+  service_account_key_file = var.service_account_key_file
+}

--- a/solutions/cloudbuild_script/example/outputs.tf
+++ b/solutions/cloudbuild_script/example/outputs.tf
@@ -1,0 +1,8 @@
+## --------------------------------------------------------------
+## Custom variable defintions
+## --------------------------------------------------------------
+
+output "gke_cluster_name" {
+  value       = module.la_asm_cluster.gke_cluster_name
+  description = "Name of the GKE cluster"
+}

--- a/solutions/cloudbuild_script/example/provider.tf
+++ b/solutions/cloudbuild_script/example/provider.tf
@@ -1,0 +1,13 @@
+provider "google" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+  zone    = var.gcp_zone
+  version = "4.3.0"
+}
+
+provider "google-beta" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+  zone    = var.gcp_zone
+  version = "4.3.0"
+}

--- a/solutions/cloudbuild_script/example/runtime.yaml
+++ b/solutions/cloudbuild_script/example/runtime.yaml
@@ -1,0 +1,2 @@
+runtime: terraform
+version: 1.0.1

--- a/solutions/cloudbuild_script/example/scripts/lab-init.sh
+++ b/solutions/cloudbuild_script/example/scripts/lab-init.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Set the Platform Project
+gcloud config set project "$1"
+
+# Create CloudBuild script 
+cat << 'EOF' > cloudbuild.yaml 
+steps:
+- id: startup_script 
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  env:
+  - 'PROJECT_ID=${_PROJECT_ID}'
+  script: |
+    #!/bin/bash
+
+    ## SCRIPT START
+    echo "Script for ${PROJECT_ID} - Replace with cool script"
+    ## SCRIPT END 
+   
+timeout: 900s
+substitutions:
+  _PROJECT_ID: project_id
+options:
+  substitution_option: 'ALLOW_LOOSE'
+EOF
+
+# Initiate CloudBuild Trigger 
+gcloud builds submit --config=cloudbuild.yaml --project="$1" --substitutions=_PROJECT_ID="$1"

--- a/solutions/cloudbuild_script/example/variables.tf
+++ b/solutions/cloudbuild_script/example/variables.tf
@@ -1,0 +1,19 @@
+#
+# ------------------  Qwiklabs Values
+#
+variable "gcp_project_id" {
+  type = string
+}
+
+variable "gcp_region" {
+  type = string
+}
+
+variable "gcp_zone" {
+  type = string
+}
+
+variable "service_account_key_file" {
+  type        = string
+  description = "key file location"
+}


### PR DESCRIPTION
Cloud Build script invoker.

Provides the ability to use Cloud Build rather than use a Compute instance. To use follow the guidance in the Google Doc.

- [x] [CloudBuild Script](https://docs.google.com/document/d/10n5RYlhSkmo8BT0_TL8TvLJ37PeCx0v9d2e1GdCcwLA/edit?resourcekey=0-Vhf2TniOeZbGdkjrw_bJcw#) documentation