### PR TITLE
n1->e2-migration

### DIFF
--- a/basics/gce_instance/README.md
+++ b/basics/gce_instance/README.md
@@ -21,7 +21,7 @@ gcp_zone       = "us-central1-a"
 #### Custom Properties
 ```
 gce_name            = var.tfResourceName
-gce_machine_type    = "n1-highmem-4"
+gce_machine_type    = "e2-highmem-4"
 gce_tags            = ["lab-vm"]
 gce_machine_image   = "debian-cloud/debian-10" 
 gce_machine_network = "default"

--- a/basics/gce_instance/dev/variables.tf
+++ b/basics/gce_instance/dev/variables.tf
@@ -61,7 +61,7 @@ variable "gce_zone" {
 variable "gce_machine_type" {
   type        = string 
   description = "Machine type to use for GCE"
-  default     = "n1-standard-1" 
+  default     = "e2-medium" 
 }
 
 # Custom properties with defaults 

--- a/basics/vpc_connector/README.md
+++ b/basics/vpc_connector/README.md
@@ -26,12 +26,11 @@ gcp_zone       = "us-central1-a"
 sva_name                   = "ideconn"
 sva_network                = "default"
 sva_subnet_cidr            = "10.8.0.0/28"
-sva_connector_machine_type = "f1-micro" 
+sva_connector_machine_type = "e2-micro" 
 ```
 
 __NOTE:__ Valid VPC Connector Machine Type are:
 
-* f1-micro
 * e2-micro
 * e2-standard-4
 

--- a/basics/vpc_connector/example/main.tf
+++ b/basics/vpc_connector/example/main.tf
@@ -16,7 +16,7 @@ module "la_serverless_vpc_access" {
   sva_name                   = "ideconn"
   sva_network                = module.la_vpc.vpc_network_name
   sva_subnet_cidr            = "10.8.0.0/28"
-  sva_connector_machine_type = "f1-micro"
+  sva_connector_machine_type = "e2-micro"
  
   ## Depends on Network
   depends_on = [ module.la_vpc ]

--- a/basics/vpc_connector/example/variables.tf
+++ b/basics/vpc_connector/example/variables.tf
@@ -52,5 +52,5 @@ variable "sva_subnet_cidr" {
 variable "sva_connector_machine_type" {
   type        = string
   description = "VPC connector machine default."
-  default     = "f1-micro" 
+  default     = "e2-micro" 
 }

--- a/basics/vpc_connector/stable/main.tf
+++ b/basics/vpc_connector/stable/main.tf
@@ -23,7 +23,7 @@ resource "google_vpc_access_connector" "connector" {
   #ip_cidr_range = "10.8.0.0/28"
   ip_cidr_range  = var.sva_subnet_cidr 
 
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   machine_type = var.sva_connector_machine_type
 
   depends_on = [

--- a/basics/vpc_connector/stable/variables.tf
+++ b/basics/vpc_connector/stable/variables.tf
@@ -52,5 +52,5 @@ variable "sva_subnet_cidr" {
 variable "sva_connector_machine_type" {
   type        = string
   description = "VPC connector machine default."
-  default     = "f1-micro" 
+  default     = "e2-micro" 
 }

--- a/solutions/asm_cluster/dev/main.tf
+++ b/solutions/asm_cluster/dev/main.tf
@@ -66,7 +66,7 @@ resource "google_container_cluster" "gke" {
 
   node_pool {
     node_config {
-      machine_type = "n1-standard-2"
+      machine_type = "e2-standard-2"
 
       oauth_scopes = [
         "https://www.googleapis.com/auth/cloud-platform"

--- a/solutions/asm_cluster/stable/main.tf
+++ b/solutions/asm_cluster/stable/main.tf
@@ -66,7 +66,7 @@ resource "google_container_cluster" "gke" {
 
   node_pool {
     node_config {
-      machine_type = "n1-standard-2"
+      machine_type = "e2-standard-2"
 
       oauth_scopes = [
         "https://www.googleapis.com/auth/cloud-platform"

--- a/solutions/cloud_labshell/stable/main.tf
+++ b/solutions/cloud_labshell/stable/main.tf
@@ -180,7 +180,7 @@ resource "google_vpc_access_connector" "connector" {
   network       = google_compute_network.dev_network.name
   ip_cidr_range = "10.8.0.0/28"
 
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   machine_type = var.vpcConnectorMachineType 
 
   depends_on = [

--- a/solutions/cloud_labshell/stable/variables.tf
+++ b/solutions/cloud_labshell/stable/variables.tf
@@ -37,7 +37,7 @@ variable "gcp_username" {
 variable "vpcConnectorMachineType" {
   type        = string
   description = "VPC Access Connector Machine Type"
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   default     = "e2-micro"
 }
 

--- a/solutions/fraudfinder/stable/main.tf
+++ b/solutions/fraudfinder/stable/main.tf
@@ -148,7 +148,7 @@ resource "google_notebooks_instance" "ff_notebook" {
   name               = "ff-jupyterlab"
   project            = var.gcp_project_id
   location           = var.gcp_zone
-  machine_type       = "n1-standard-4" // n1-standard-1 $112.91 monthly estimate
+  machine_type       = "e2-standard-4" // e2-medium $112.91 monthly estimate
   install_gpu_driver = false
   vm_image { // https://cloud.google.com/vertex-ai/docs/workbench/user-managed/images
     project      = "deeplearning-platform-release"

--- a/solutions/generative-ai/stable/variables.tf
+++ b/solutions/generative-ai/stable/variables.tf
@@ -33,7 +33,7 @@ variable "sme_notebook_name" {
 variable "sme_machine_type" {
   type        = string
   description = "Notebook machine type"
-  default     = "n1-standard-4"
+  default     = "e2-standard-4"
 }
 
 variable "sme_image_project" {

--- a/solutions/ide_cloud_code/dev/main.tf
+++ b/solutions/ide_cloud_code/dev/main.tf
@@ -133,7 +133,7 @@ resource "google_vpc_access_connector" "connector" {
   network       = google_compute_network.dev_network.name
   ip_cidr_range = "10.8.0.0/28"
 
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   machine_type = var.vpcConnectorMachineType
 
   depends_on = [

--- a/solutions/ide_cloud_code/dev/variables.tf
+++ b/solutions/ide_cloud_code/dev/variables.tf
@@ -51,7 +51,7 @@ variable "vpcSubnetName" {
 variable "vpcConnectorMachineType" {
   type        = string 
   description = "VPC Access Connector Machine Type"
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   default     = "e2-micro" 
 }
 

--- a/solutions/ide_cloud_code/stable/main.tf
+++ b/solutions/ide_cloud_code/stable/main.tf
@@ -133,7 +133,7 @@ resource "google_vpc_access_connector" "connector" {
   network       = google_compute_network.dev_network.name
   ip_cidr_range = "10.8.0.0/28"
 
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   machine_type = var.vpcConnectorMachineType
 
   depends_on = [

--- a/solutions/ide_cloud_code/stable/variables.tf
+++ b/solutions/ide_cloud_code/stable/variables.tf
@@ -52,7 +52,7 @@ variable "vpcSubnetName" {
 variable "vpcConnectorMachineType" {
   type        = string 
   description = "VPC Access Connector Machine Type"
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   default     = "e2-micro" 
 }
 

--- a/solutions/ide_cloudshell/dev/main.tf
+++ b/solutions/ide_cloudshell/dev/main.tf
@@ -180,7 +180,7 @@ resource "google_vpc_access_connector" "connector" {
   network       = google_compute_network.dev_network.name
   ip_cidr_range = "10.8.0.0/28"
 
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   machine_type = var.vpcConnectorMachineType 
 
   depends_on = [

--- a/solutions/ide_cloudshell/dev/variables.tf
+++ b/solutions/ide_cloudshell/dev/variables.tf
@@ -37,7 +37,7 @@ variable "gcp_username" {
 variable "vpcConnectorMachineType" {
   type        = string
   description = "VPC Access Connector Machine Type"
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   default     = "e2-micro"
 }
 

--- a/solutions/ide_cloudshell/stable/main.tf
+++ b/solutions/ide_cloudshell/stable/main.tf
@@ -157,7 +157,7 @@ resource "google_vpc_access_connector" "connector" {
   network       = google_compute_network.dev_network.name
   ip_cidr_range = "10.8.0.0/28"
 
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   machine_type = var.vpcConnectorMachineType 
 
   depends_on = [

--- a/solutions/ide_cloudshell/stable/variables.tf
+++ b/solutions/ide_cloudshell/stable/variables.tf
@@ -37,7 +37,7 @@ variable "gcp_username" {
 variable "vpcConnectorMachineType" {
   type        = string
   description = "VPC Access Connector Machine Type"
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   default     = "e2-micro"
 }
 

--- a/solutions/ide_tensorflow/stable/main.tf
+++ b/solutions/ide_tensorflow/stable/main.tf
@@ -157,7 +157,7 @@ resource "google_vpc_access_connector" "connector" {
   network       = google_compute_network.dev_network.name
   ip_cidr_range = "10.8.0.0/28"
 
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   machine_type = var.vpcConnectorMachineType 
 
   depends_on = [

--- a/solutions/ide_tensorflow/stable/variables.tf
+++ b/solutions/ide_tensorflow/stable/variables.tf
@@ -36,7 +36,7 @@ variable "gcp_username" {
 variable "vpcConnectorMachineType" {
   type        = string
   description = "VPC Access Connector Machine Type"
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   default     = "e2-micro"
 }
 

--- a/solutions/ide_web/dev/main.tf
+++ b/solutions/ide_web/dev/main.tf
@@ -47,7 +47,7 @@ module "la_serverless_vpc_access" {
   sva_name                   = "ideconn"
   sva_network                = module.la_vpc.vpc_network_name
   sva_subnet_cidr            = "10.8.0.0/28" 
-  sva_connector_machine_type = "f1-micro" 
+  sva_connector_machine_type = "e2-micro" 
 
   depends_on = [ module.la_vpc ]
 }

--- a/solutions/ide_web/dev/variables.tf
+++ b/solutions/ide_web/dev/variables.tf
@@ -37,7 +37,7 @@ variable "gcp_username" {
 variable "vpcConnectorMachineType" {
   type        = string
   description = "VPC Access Connector Machine Type"
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   default     = "e2-micro"
 }
 

--- a/solutions/ide_web/stable/main.tf
+++ b/solutions/ide_web/stable/main.tf
@@ -47,7 +47,7 @@ module "la_serverless_vpc_access" {
   sva_name                   = "ideconn"
   sva_network                = module.la_vpc.vpc_network_name
   sva_subnet_cidr            = "10.8.0.0/28" 
-  sva_connector_machine_type = "f1-micro" 
+  sva_connector_machine_type = "e2-micro" 
 
   depends_on = [ module.la_vpc ]
 }

--- a/solutions/ide_web/stable/variables.tf
+++ b/solutions/ide_web/stable/variables.tf
@@ -37,7 +37,7 @@ variable "gcp_username" {
 variable "vpcConnectorMachineType" {
   type        = string
   description = "VPC Access Connector Machine Type"
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   default     = "e2-micro"
 }
 

--- a/solutions/lab_proxy/dev/main.tf
+++ b/solutions/lab_proxy/dev/main.tf
@@ -21,7 +21,7 @@ resource "google_vpc_access_connector" "connector" {
   network       = var.vpcNetworkName 
   ip_cidr_range = "10.8.0.0/28"
 
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   machine_type = var.vpcConnectorMachineType
 
   depends_on = [ google_project_service.vpcaccess-api ]

--- a/solutions/lab_proxy/dev/variables.tf
+++ b/solutions/lab_proxy/dev/variables.tf
@@ -40,7 +40,7 @@ variable "vpcSubnetName" {
 variable "vpcConnectorMachineType" {
   type        = string 
   description = "VPC Access Connector Machine Type"
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   default     = "e2-micro" 
 }
 

--- a/solutions/proxy_vertex_workbench/dev/main.tf
+++ b/solutions/proxy_vertex_workbench/dev/main.tf
@@ -178,7 +178,7 @@ resource "google_vpc_access_connector" "connector" {
   network       = google_compute_network.dev_network.id
   ip_cidr_range = "10.8.0.0/28"
 
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   machine_type = var.vpcConnectorMachineType
 
   # https://github.com/google/exposure-notifications-server/issues/932

--- a/solutions/proxy_vertex_workbench/dev/variables.tf
+++ b/solutions/proxy_vertex_workbench/dev/variables.tf
@@ -54,7 +54,7 @@ variable "vm_zone" {
 variable "machine_type" {
   type        = string
   description = "Machine type to use for GCE"
-  default     = "n1-standard-1"
+  default     = "e2-medium"
 }
 
 # Custom properties with defaults 
@@ -92,7 +92,7 @@ variable "vm_scopes" {
 variable "vpcConnectorMachineType" {
   type        = string
   description = "VPC Access Connector Machine Type"
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   default = "e2-micro"
 }
 

--- a/solutions/proxy_vertex_workbench/stable/main.tf
+++ b/solutions/proxy_vertex_workbench/stable/main.tf
@@ -178,7 +178,7 @@ resource "google_vpc_access_connector" "connector" {
   network       = google_compute_network.dev_network.id
   ip_cidr_range = "10.8.0.0/28"
 
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   machine_type = var.vpcConnectorMachineType
 
   # https://github.com/google/exposure-notifications-server/issues/932

--- a/solutions/proxy_vertex_workbench/stable/variables.tf
+++ b/solutions/proxy_vertex_workbench/stable/variables.tf
@@ -54,7 +54,7 @@ variable "vm_zone" {
 variable "machine_type" {
   type        = string
   description = "Machine type to use for GCE"
-  default     = "n1-standard-1"
+  default     = "e2-medium"
 }
 
 # Custom properties with defaults 
@@ -92,7 +92,7 @@ variable "vm_scopes" {
 variable "vpcConnectorMachineType" {
   type        = string
   description = "VPC Access Connector Machine Type"
-  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  # Note: valid options: e2-micro, e2-standard-4
   default = "e2-micro"
 }
 


### PR DESCRIPTION
As requested by Sam, we need to use e2 instances whenever possible. There is a project going on, to go through each lab and replace the instance types by their e2 equivalent ones. I just did that with this repo. 