### PR TITLE
LA Proxy - add mandatory parameters

### DIFF
--- a/solutions/lab_proxy/dev/main.tf
+++ b/solutions/lab_proxy/dev/main.tf
@@ -18,13 +18,16 @@ resource "google_vpc_access_connector" "connector" {
   provider      = google-beta
   name          = "ideconn"
   region        = var.gcp_region
-  network       = var.vpcNetworkName 
+  network       = var.vpcNetworkName
   ip_cidr_range = "10.8.0.0/28"
+
+  min_throughput = 200
+  max_throughput = 300
 
   # Note: valid options: f1-micro, e2-micro, e2-standard-4
   machine_type = var.vpcConnectorMachineType
 
-  depends_on = [ google_project_service.vpcaccess-api ]
+  depends_on = [google_project_service.vpcaccess-api]
 }
 
 
@@ -46,7 +49,7 @@ resource "google_project_service" "run" {
 
 
 resource "google_cloud_run_service" "ide" {
-  name     = var.gcrServiceName
+  name = var.gcrServiceName
   # location = var.gcrRegion
   location = var.gcp_region
 
@@ -54,7 +57,7 @@ resource "google_cloud_run_service" "ide" {
     spec {
       containers {
         # image = "gcr.io/qwiklabs-resources/ide-proxy:latest"
-        image = var.gcrContainerImage 
+        image = var.gcrContainerImage
       }
       container_concurrency = 2
     }
@@ -76,7 +79,7 @@ resource "google_cloud_run_service" "ide" {
   }
 
   # Dependency - Cloud Run API enabled
-  depends_on = [google_project_service.run, google_vpc_access_connector.connector ] 
+  depends_on = [google_project_service.run, google_vpc_access_connector.connector]
 }
 
 

--- a/solutions/lab_proxy/dev/outputs.tf
+++ b/solutions/lab_proxy/dev/outputs.tf
@@ -3,6 +3,6 @@
 ## --------------------------------------------------------------
 
 output "ideEditorService" {
-  value       = "${google_cloud_run_service.ide.status[0].url}"
+  value       = google_cloud_run_service.ide.status[0].url
   description = "URL of the IDE service"
 }

--- a/solutions/lab_proxy/dev/variables.tf
+++ b/solutions/lab_proxy/dev/variables.tf
@@ -38,10 +38,10 @@ variable "vpcSubnetName" {
 
 # Custom properties with defaults 
 variable "vpcConnectorMachineType" {
-  type        = string 
+  type        = string
   description = "VPC Access Connector Machine Type"
   # Note: valid options: f1-micro, e2-micro, e2-standard-4
-  default     = "e2-micro" 
+  default = "e2-micro"
 }
 
 variable "gcrServiceName" {


### PR DESCRIPTION
[VPC connectors](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vpc_access_connector) must not specify on of the following:

* max_throughput
* max_instances

Updated the Terraform module to include the `min_throughput` and `max_throughput` settings.

- [x] Add: Mandatory parameters
- [x] Terraform formatting
- [ ] TODO: Migrate the IDE modules to use this `LA_PROXY` module.