### PR TITLE
Add: Firewall + Variables to enable comms

### DIFF
--- a/solutions/ide_cloud_code/stable/main.tf
+++ b/solutions/ide_cloud_code/stable/main.tf
@@ -342,7 +342,7 @@ module "la_fw" {
     {
       fwr_name                    = "network-allow-internal"
       fwr_description             = "Private internal communication"
-      fwr_source_ranges           = [ "${var.vpcSubnetCidr}" ]
+      fwr_source_ranges           = [ "${var.vpcSubnetCidr}", "${var.vpcDefaultCidr}" ]
       fwr_destination_ranges      = null
       fwr_source_tags             = null
       fwr_source_service_accounts = null
@@ -427,7 +427,7 @@ resource "google_cloud_run_v2_service" "ide" {
   launch_stage = "BETA"
   template {
     containers {
-      image = "gcr.io/qwiklabs-resources/test-ide-proxy:latest"
+      image = var.gcrContainerImage 
     }
     vpc_access{
       network_interfaces {

--- a/solutions/ide_cloud_code/stable/variables.tf
+++ b/solutions/ide_cloud_code/stable/variables.tf
@@ -62,6 +62,13 @@ variable "vpcSubnetCidr" {
   default     = "10.1.0.0/24"
 }
 
+# Custom properties with defaults 
+variable "vpcDefaultCidr" {
+  type        = string
+  description = "Network custom CIDR"
+  default     = "10.128.0.0/9"
+}
+
 ## # Custom properties with defaults 
 ## variable "vpcConnectorMachineType" {
 ##   type        = string 
@@ -163,10 +170,13 @@ variable "gkeMasterIPv4CIDRBlock" {
   default = "172.23.0.0/28"
 }
 
+## Cloud Run Settings
+#
+
 # Custom properties with defaults 
-variable "gkeRegion" {
-  type        = string 
-  description = "Region to create resources in."
-  default     = "us-central1" 
+variable "gcrContainerImage" {
+  type        = string
+  description = "Container Image."
+  default     = "gcr.io/qwiklabs-resources/test-ide-proxy:latest" 
 }
 


### PR DESCRIPTION
Variables definitions:

- [x] Add Container image
- [x] Add Cidr range to FW for GKE communication
- [x] Set the default network `10.128.0.0/9` range in the FW
- [x] Remove the alternative `gkeRegion` variable, default to the platform value