### PR TITLE
Debian 11 Upgrade

### DIFF
--- a/basics/vai_notebook/stable/variables.tf
+++ b/basics/vai_notebook/stable/variables.tf
@@ -81,7 +81,8 @@ variable "vai_machine_image" {
 variable "vai_image_family" {
   type        = string
   description = "GCE image family"
-  default     = "common-cpu-notebooks-debian-10"
+  # default     = "common-cpu-notebooks-debian-10"
+  default     = "common-cpu-notebooks-debian-11"
 }
 
 # Custom properties with defaults 


### PR DESCRIPTION
Module:  VIA_NOTEBOOK
Ref: https://buganizer.corp.google.com/issues/326388441

- [x] Update compute image to Debian 11.