### PR TITLE
Verrext AI Workbook: Transition to Debian 11

### DIFF
--- a/solutions/proxy_vertex_workbench/stable/variables.tf
+++ b/solutions/proxy_vertex_workbench/stable/variables.tf
@@ -169,7 +169,7 @@ variable "gceImageProject" {
 variable "gceInstanceImage" {
   type        = string
   description = "GCE Image family"
-  default     = "common-cpu-notebooks-debian-10"
+  default     = "common-cpu-notebooks-debian-11"
 }
 
 # Custom properties with defaults 


### PR DESCRIPTION
Migrate lab from Debian 10 to Debian 11.

Ref: https://buganizer.corp.google.com/issues/326388441