### PR TITLE
CF Gen 1 Fix: Data type invalid

### DIFF
--- a/basics/cloud_function/dev/variables.tf
+++ b/basics/cloud_function/dev/variables.tf
@@ -118,7 +118,7 @@ variable "gcf_timeout" {
 }
 
 variable "gcf_trigger_http" {
-  type        = boolean 
+  type        = bool 
   description = "Trigger on http request."
   default     = true 
 }


### PR DESCRIPTION
Cloud Function Update
Channel: Dev

- [ ] Fix invalid data type - TF uses `bool`.

Ref: https://developer.hashicorp.com/terraform/language/expressions/types