### PR TITLE
CF Gen 1: Amend the docker registry

### DIFF
--- a/basics/cloud_function/dev/variables.tf
+++ b/basics/cloud_function/dev/variables.tf
@@ -102,7 +102,8 @@ variable "gcf_environment_variables" {
 variable "gcf_registry" {
   type        = string
   description = "Registry type to use."
-  default     = "ARTIFACT_REGISTRY"
+  # default     = "ARTIFACT_REGISTRY"
+  default     = "CONTAINER_REGISTRY"
 }
 
 variable "gcf_available_mb" {


### PR DESCRIPTION
Cloud Function Update
Channel: Dev

Amend docker registry to have a default of Container Registry. A temporary step to ease the transition to Artifact Registry.

Dev Channel can be promoted to stable, with this change.

- [x] Add: CONTAINER_REGISTRY as default