### PR TITLE
Revert "Cloud Function Gen 1: Promote Dev Channel to Stable"

### DIFF
--- a/basics/cloud_function/example/main.tf
+++ b/basics/cloud_function/example/main.tf
@@ -2,19 +2,6 @@
 # Local:  modules/[channel]
 # Remote: github.com://CloudVLab/terraform-lab-foundation//[module]/[channel]
 
-# Locals: Variables
-# ----------------------------------------------------------------------------
-# Set the Cloud Function properties
-locals {
-  cloud_function_name         = "myfunction"
-  cloud_function_description  = "Test Cloud Function"
-  cloud_function_runtime      = "nodejs16"
-  cloud_function_entrypoint   = "httpHello"
-  cloud_function_object       = "function.zip"
-  cloud_function_path         = "./cf/"
-  cloud_function_bucket_ext   = "mybucket"
-}
-
 # Module: Cloud Functions
 module "la_gcf" {
   source = "github.com/CloudVLab/terraform-lab-foundation//basics/cloud_function/stable"
@@ -28,14 +15,15 @@ module "la_gcf" {
   gcs_bucket_extension = "bucket"
 
   # Customise the Cloud Function
-  gcf_name                  = "${local.cloud_function_name}"
-  gcf_description           = "${local.cloud_function_description}"
-  gcf_runtime               = "${local.cloud_function_runtime}"
-  gcf_target_bucket         = "${local.cloud_function_bucket_ext}"
-  gcf_archive_source        = "${local.cloud_function_path}${local.cloud_function_object}"
-  gcf_archive_object        = "${local.cloud_function_object}"
-  gcf_entry_point           = "${local.cloud_function_entrypoint}"
+  gcf_name                  = "myfunction"
+  gcf_description           = "Test Cloud Function"
+  gcf_runtime               = "nodejs16"
+  gcf_target_bucket         = "mybucket"
+  gcf_archive_source        = "./cf/function.zip"
+  gcf_entry_point           = "httpHello"
   gcf_environment_variables = {
     PROJECT_ID = var.gcp_project_id
+    BUCKETNAME = "${var.gcp.project_id}-bucket" 
+    FILENAME   = "tasks.json"
   }
 }

--- a/basics/cloud_function/example/outputs.tf
+++ b/basics/cloud_function/example/outputs.tf
@@ -1,1 +1,1 @@
-## Expose Cloud Function properties
+## Expose Cloud Firestore properties

--- a/basics/cloud_function/stable/main.tf
+++ b/basics/cloud_function/stable/main.tf
@@ -13,11 +13,13 @@ resource "google_storage_bucket" "bucket" {
 }
 
 resource "google_storage_bucket_object" "archive" {
-  name   = var.gcf_archive_object
+  name   = var.gcf_archive_object 
+  #name   = "mostplayed.zip" 
   bucket = google_storage_bucket.bucket.name
-  source = var.gcf_archive_source
+  source = var.gcf_archive_source 
+  #source = "./cf/mostplayed.zip" 
 
-  depends_on = [google_storage_bucket.bucket]
+  depends_on = [ google_storage_bucket.bucket ]
 }
 
 #
@@ -27,25 +29,27 @@ resource "google_storage_bucket_object" "archive" {
 ## NEW Module: Cloud Function
 
 resource "google_cloudfunctions_function" "custom_function" {
-  name        = var.gcf_name
-  project     = var.gcp_project_id
-  region      = var.gcp_region
-  description = var.gcf_description
-  runtime     = var.gcf_runtime
+  name                  = var.gcf_name 
+  project               = var.gcp_project_id
+  region                = var.gcp_region
+  description           = var.gcf_description 
+  runtime               = var.gcf_runtime
 
+  available_memory_mb   = 128
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.archive.name
-  entry_point           = var.gcf_entry_point
+  ## source_archive_bucket = var.gcf_target_bucket 
+  ## source_archive_object = var.gcf_archive_source
+  trigger_http          = true
+  entry_point           = var.gcf_entry_point 
 
-  ## Ref: CR/AF Migration 
-  available_memory_mb          = var.gcf_available_mb
-  docker_registry              = var.gcf_registry
-  timeout                      = var.gcf_timeout
-  trigger_http                 = var.gcf_trigger_http
-  https_trigger_security_level = var.gcf_trigger_security
-  environment_variables        = var.gcf_environment_variables
+#  environment_variables = {
+#    PROJECT_ID= var.gcp_project_id
+#  }
 
-  depends_on = [google_storage_bucket_object.archive]
+  environment_variables = var.gcf_environment_variables
+
+  depends_on = [ google_storage_bucket_object.archive ]
 }
 
 #
@@ -60,6 +64,6 @@ resource "google_cloudfunctions_function_iam_member" "invoker" {
   project        = var.gcp_project_id
   region         = var.gcp_region
   cloud_function = google_cloudfunctions_function.custom_function.name
-  role           = var.gcf_role_bind
-  member         = var.gcf_member_account
+  role           = var.gcf_role_bind 
+  member         = var.gcf_member_account 
 }

--- a/basics/cloud_function/stable/variables.tf
+++ b/basics/cloud_function/stable/variables.tf
@@ -95,37 +95,6 @@ variable "gcf_environment_variables" {
   type = map(string)
 
   default = {
-    PROJECT_ID = "undefined"
+    PROJECT_ID = "undefined" 
   }
-}
-
-variable "gcf_registry" {
-  type        = string
-  description = "Registry type to use."
-  # default     = "ARTIFACT_REGISTRY"
-  default = "CONTAINER_REGISTRY"
-}
-
-variable "gcf_available_mb" {
-  type        = number
-  description = "Amount of memory to allocate."
-  default     = 128
-}
-
-variable "gcf_timeout" {
-  type        = number
-  description = "Cloud Function timeout delay, defaults to 60s."
-  default     = 60
-}
-
-variable "gcf_trigger_http" {
-  type        = bool
-  description = "Trigger on http request."
-  default     = true
-}
-
-variable "gcf_trigger_security" {
-  type        = string
-  description = "Redirect to HTTP URL, support query params."
-  default     = "SECURE_ALWAYS"
 }


### PR DESCRIPTION
Reverts CloudVLab/terraform-lab-foundation#373

We're seeing a bunch of lab launch errors across Qwiklabs after this PR got merged. Reverting for now because we think that will fix the problem.

I know the formatting is terrible but hopefully this error is almost human-readable:

```
INFO 2024-04-05T14:22:55.415505433Z [resource.labels.instanceId: 7725423000572245687] Execution failed, message for user: [Error executing terraform apply [Error: Unsupported argument], see logs for additional details.]\r\n
INFO 2024-04-05T14:22:55.415600045Z [resource.labels.instanceId: 7725423000572245687] Command returned status 1. Logs: [\x1b[31m\xe2\x95\xb7\x1b[0m\x1b[0m\r\n
INFO 2024-04-05T14:22:55.415631361Z [resource.labels.instanceId: 7725423000572245687] \x1b[31m\xe2\x94\x82\x1b[0m \x1b[0m\x1b[1m\x1b[31mError: \x1b[0m\x1b[0m\x1b[1mUnsupported argument\x1b[0m\r\n
INFO 2024-04-05T14:22:55.415635700Z [resource.labels.instanceId: 7725423000572245687] \x1b[31m\xe2\x94\x82\x1b[0m \x1b[0m\r\n
INFO 2024-04-05T14:22:55.415641287Z [resource.labels.instanceId: 7725423000572245687] \x1b[31m\xe2\x94\x82\x1b[0m \x1b[0m\x1b[0m on .terraform/modules/la_gcf/basics/cloud_function/stable/main.tf line 42, in resource \"google_cloudfunctions_function\" \"custom_function\":\r\n
INFO 2024-04-05T14:22:55.415648245Z [resource.labels.instanceId: 7725423000572245687] \x1b[31m\xe2\x94\x82\x1b[0m \x1b[0m 42: \x1b[4mdocker_registry\x1b[0m = var.gcf_registry\x1b[0m\r\n
INFO 2024-04-05T14:22:55.415653535Z [resource.labels.instanceId: 7725423000572245687] \x1b[31m\xe2\x94\x82\x1b[0m \x1b[0m\r\n
INFO 2024-04-05T14:22:55.465829986Z [resource.labels.instanceId: 7725423000572245687] \x1b[31m\xe2\x94\x82\x1b[0m \x1b[0mAn argument named \"docker_registry\" is not expected here.\r\n
INFO 2024-04-05T14:22:55.465849315Z [resource.labels.instanceId: 7725423000572245687] \x1b[31m\xe2\x95\xb5\x1b[0m\x1b[0m\r\n
INFO 2024-04-05T14:22:55.465853386Z [resource.labels.instanceId: 7725423000572245687] \x1b[31m\xe2\x95\xb7\x1b[0m\x1b[0m\r\n
INFO 2024-04-05T14:22:55.465858091Z [resource.labels.instanceId: 7725423000572245687] \x1b[31m\xe2\x94\x82\x1b[0m \x1b[0m\x1b[1m\x1b[31mError: \x1b[0m\x1b[0m\x1b[1mUnsupported argument\x1b[0m\r\n
INFO 2024-04-05T14:22:55.465862800Z [resource.labels.instanceId: 7725423000572245687] \x1b[31m\xe2\x94\x82\x1b[0m \x1b[0m\r\n
INFO 2024-04-05T14:22:55.465868018Z [resource.labels.instanceId: 7725423000572245687] \x1b[31m\xe2\x94\x82\x1b[0m \x1b[0m\x1b[0m on .terraform/modules/la_gcf/basics/cloud_function/stable/main.tf line 45, in resource \"google_cloudfunctions_function\" \"custom_function\":\r\n
INFO 2024-04-05T14:22:55.465872068Z [resource.labels.instanceId: 7725423000572245687] \x1b[31m\xe2\x94\x82\x1b[0m \x1b[0m 45: \x1b[4mhttps_trigger_security_level\x1b[0m = var.gcf_trigger_security\x1b[0m\r\n
INFO 2024-04-05T14:22:55.465875908Z [resource.labels.instanceId: 7725423000572245687] \x1b[31m\xe2\x94\x82\x1b[0m \x1b[0m\r\n
INFO 2024-04-05T14:22:55.465879642Z [resource.labels.instanceId: 7725423000572245687] \x1b[31m\xe2\x94\x82\x1b[0m \x1b[0mAn argument named \"https_trigger_security_level\" is not expected here.\r\n
INFO 2024-04-05T14:22:55.465882775Z [resource.labels.instanceId: 7725423000572245687] \x1b[31m\xe2\x95\xb5\x1b[0m\x1b[0m\r\n
INFO 2024-04-05T14:22:55.465887122Z [resource.labels.instanceId: 7725423000572245687] ]\r\n
INFO 2024-04-05T14:22:55.516058970Z [resource.labels.instanceId: 7725423000572245687] Traceback (most recent call last):\r\n
INFO 2024-04-05T14:22:55.516077522Z [resource.labels.instanceId: 7725423000572245687] File \"/app/execution_service.py\", line 236, in execute_script\r\n
INFO 2024-04-05T14:22:55.516082290Z [resource.labels.instanceId: 7725423000572245687] output = self._execute(execution_id=execution_id,\r\n
INFO 2024-04-05T14:22:55.516086457Z [resource.labels.instanceId: 7725423000572245687] File \"/app/execution_service.py\", line 189, in _execute\r\n
INFO 2024-04-05T14:22:55.516120590Z [resource.labels.instanceId: 7725423000572245687] return self._runtime_service.execute(\r\n
INFO 2024-04-05T14:22:55.516125180Z [resource.labels.instanceId: 7725423000572245687] File \"/app/runtime_service.py\", line 112, in execute\r\n
INFO 2024-04-05T14:22:55.516132055Z [resource.labels.instanceId: 7725423000572245687] return self._runtimes[runtime_].execute(\r\n
INFO 2024-04-05T14:22:55.516137089Z [resource.labels.instanceId: 7725423000572245687] File \"/app/runtimes/terraform_runtime.py\", line 97, in execute\r\n
INFO 2024-04-05T14:22:55.516142149Z [resource.labels.instanceId: 7725423000572245687] raise exceptions.FailedExecution(\r\n
INFO 2024-04-05T14:22:55.516146837Z [resource.labels.instanceId: 7725423000572245687] exceptions.FailedExecution\r\n
```

And view from Cloud Logging which is slightly better but also an image of text:

![image](https://github.com/CloudVLab/terraform-lab-foundation/assets/869213/ac01c021-a5a4-439c-b341-ade6e3f89892)
