### PR TITLE
GCE: Fix for invalid variable name

### DIFF
--- a/basics/gce_instance/dev/outputs.tf
+++ b/basics/gce_instance/dev/outputs.tf
@@ -8,7 +8,7 @@
 # }
 
 output "gce_external_ip" {
-  value = var.assign_external_ip ? (
+  value = var.gce_assign_external_ip ? (
     google_compute_instance.gce_virtual_machine.network_interface.0.access_config.0.nat_ip
   ) : null
   description = "External IP address of GCE instance"


### PR DESCRIPTION
Fix: Output variable

- [ ] If external IP not used, need to return null for IP value.