### PR TITLE
Add: Initial migration effort split out of Cloud Run

### DIFF
--- a/basics/cloud_run/example/main.tf
+++ b/basics/cloud_run/example/main.tf
@@ -2,9 +2,11 @@
 # Local:  modules/[channel]
 # Remote: github.com://CloudVLab/terraform-lab-foundation//[module]/[channel]
 
-# Module: AutoML  
+# Module: Cloud Run 
 module "la_cloud_run" {
   #source = "github.com/CloudVLab/terraform-lab-foundation//basics/cloud_run/stable?ref=tlf-basics"
+  # source = "github.com/CloudVLab/terraform-lab-foundation//basics/cloud_run/stable/v1"
+  # source = "gcs::https://storage.googleapis.com/terraform-lab-foundation/basics/cloud_run/stable"
   source = "github.com/CloudVLab/terraform-lab-foundation//basics/cloud_run/stable"
 
   # Pass values to the module
@@ -13,8 +15,8 @@ module "la_cloud_run" {
   gcp_zone       = var.gcp_zone
 
   # Customise the GCE instance
+  gcrRegion  = var.gcp_region 
   #gcrService = "automl-proxy"
   #gcrImage   = "gcr.io/qwiklabs-resources/ide-proxy:latest"
-  #gcrRegion  = "us-central1"
   #gcrEnvs    = [ { "URL", "https://storage.googleapis.com/spl-api/test2.json" } ]
 }

--- a/basics/cloud_run/example/versions.tf
+++ b/basics/cloud_run/example/versions.tf
@@ -1,0 +1,13 @@
+# versions.tf
+terraform {
+  required_providers {
+    google = {
+      # https://registry.terraform.io/providers/hashicorp/google/latest
+      version = "5.6.0"
+    }
+    google-beta = {
+      # https://registry.terraform.io/providers/hashicorp/google-beta/latest
+      version = "5.6.0"
+    }
+  }
+}

--- a/basics/cloud_run/stable/v1/main.tf
+++ b/basics/cloud_run/stable/v1/main.tf
@@ -1,0 +1,74 @@
+# Reference:
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service
+#
+# Enable the Cloud Run service
+resource "google_project_service" "run" {
+  project = var.gcp_project_id
+  service = "run.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  # disable_dependent_services = true
+}
+
+resource "google_cloud_run_service" "proxy" {
+  name     = var.gcrService
+  project  = var.gcp_project_id
+  # location = var.gcrRegion
+  location = var.gcp_region
+
+  template {
+    spec {
+      containers {
+        image = var.gcrImage
+
+        ## Add environment variable
+        dynamic "env" {
+          for_each = var.gcrEnvs
+          content {
+            name  = env.value.gcr_env_name
+            value = env.value.gcr_env_value
+          }
+        }
+      }
+      container_concurrency = 2
+    }
+
+    # Add support for vpc connector
+    metadata {
+      annotations = {
+        "autoscaling.knative.dev/maxScale" = "3"
+        "autoscaling.knative.dev/minScale" = "1"
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+
+  # Dependency - Cloud Run API enabled
+  depends_on = [google_project_service.run]
+}
+
+
+data "google_iam_policy" "noauth" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "allUsers",
+    ]
+  }
+}
+
+resource "google_cloud_run_service_iam_policy" "noauth" {
+  location = google_cloud_run_service.proxy.location
+  project  = google_cloud_run_service.proxy.project
+  service  = google_cloud_run_service.proxy.name
+
+  policy_data = data.google_iam_policy.noauth.policy_data
+}

--- a/basics/cloud_run/stable/v1/outputs.tf
+++ b/basics/cloud_run/stable/v1/outputs.tf
@@ -1,0 +1,8 @@
+## --------------------------------------------------------------
+## Custom variable definitions
+## --------------------------------------------------------------
+
+output "gcr_service_url" {
+  value       = google_cloud_run_service.proxy.status[0].url
+  description = "URL of the Cloud Run service"
+}

--- a/basics/cloud_run/stable/v1/runtime.yaml
+++ b/basics/cloud_run/stable/v1/runtime.yaml
@@ -1,0 +1,2 @@
+runtime: terraform
+version: 1.0.1

--- a/basics/cloud_run/stable/v1/test.tfvars
+++ b/basics/cloud_run/stable/v1/test.tfvars
@@ -1,0 +1,5 @@
+gcp_project_id = "qwiklabs-resources"
+gcp_region     = "us-central1"
+gcp_zone       = "us-central1-a"
+gcp_username   = "test-suite@qwiklabs.com"
+gce_name       = "test-vm"

--- a/basics/cloud_run/stable/v1/variables.tf
+++ b/basics/cloud_run/stable/v1/variables.tf
@@ -1,0 +1,52 @@
+## --------------------------------------------------------------
+## Mandatory variable definitions
+## --------------------------------------------------------------
+
+variable "gcp_project_id" {
+  type        = string
+  description = "The GCP project ID to create resources in."
+}
+
+# Default value passed in
+variable "gcp_region" {
+  type        = string
+  description = "Region to create resources in."
+}
+
+# Default value passed in
+variable "gcp_zone" {
+  type        = string
+  description = "Zone to create resources in."
+}
+
+
+## --------------------------------------------------------------
+## Custom variable definitions - Override from Custom Properties
+## --------------------------------------------------------------
+
+variable "gcrService" {
+  type        = string
+  description = "Name of the proxy service"
+  default     = "automl-proxy"
+}
+
+variable "gcrRegion" {
+  type        = string
+  description = "GCE virtual machine image family"
+  default     = "us-central1"
+}
+
+variable "gcrImage" {
+  type        = string
+  description = "GCE virtual machine image family"
+  default     = "gcr.io/qwiklabs-resources/automl-proxy:latest"
+}
+
+variable "gcrEnvs" {
+  description = "List of custom rule definitions (refer to variables file for syntax)."
+  default     = []
+  type = list(object({
+    gcr_env_name  = string,
+    gcr_env_value = string
+  }))
+}

--- a/basics/cloud_run/stable/v2/api.tf
+++ b/basics/cloud_run/stable/v2/api.tf
@@ -1,0 +1,21 @@
+# Enable Googleapis  
+
+## Googleapis 
+## ----------------------------------------------------------------------------
+
+# Module: Enable Google APIs
+module "la_api_batch" {
+  source = "github.com/CloudVLab/terraform-lab-foundation//basics/api_service/dev"
+
+  # Pass values to the module
+  gcp_project_id = var.gcp_project_id
+  gcp_region     = var.gcp_region
+  gcp_zone       = var.gcp_zone
+
+  # Customise the APIs
+  ## VPC Access   - Direct VPC
+  ## Run          - Cloud Run
+  ## AI companion - Duet AI
+  api_services = [ "vpcaccess.googleapis.com", "run.googleapis.com", "cloudaicompanion.googleapis.com" ] 
+}
+

--- a/basics/cloud_run/stable/v2/cr.tf
+++ b/basics/cloud_run/stable/v2/cr.tf
@@ -1,0 +1,35 @@
+# TODO: Migrate to Module - Cloud Run V2 
+
+
+## Create a Cloud Run container 
+## ----------------------------------------------------------------------------
+
+resource "google_cloud_run_v2_service" "ide" {
+  name     = var.gcrIDEService 
+  location = var.gcp_region 
+  launch_stage = "BETA"
+  template {
+    containers {
+      image = "gcr.io/qwiklabs-resources/test-ide-proxy:latest"
+    }
+    vpc_access{
+      network_interfaces {
+        network = module.la_vpc.vpc_network_name
+        subnetwork = module.la_vpc.vpc_subnetwork_name
+        # network = google_compute_network.dev_network.id 
+        # subnetwork = google_compute_subnetwork.dev_subnet.id
+        tags = var.gceInstanceTags
+      }
+      egress = "ALL_TRAFFIC"
+    }
+  }
+}
+
+resource "google_cloud_run_service_iam_binding" "public" {
+  location = google_cloud_run_v2_service.ide.location
+  service  = google_cloud_run_v2_service.ide.name
+  role     = "roles/run.invoker"
+  members  = [
+    "allUsers"
+  ]
+}

--- a/basics/cloud_run/stable/v2/fw.tf
+++ b/basics/cloud_run/stable/v2/fw.tf
@@ -1,0 +1,89 @@
+# Module: Virtual Private Cloud
+
+## ----------------------------------------------------------------------------
+# Reference:
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall
+# https://github.com/terraform-google-modules/terraform-google-network/tree/master/modules/firewall-rules
+
+module "la_fw" {
+  ## NOTE: When changing the source parameter, `terraform init` is required
+
+  ## REMOTE: GitHub (Public) access - working 
+  source = "github.com/CloudVLab/terraform-lab-foundation//basics/vpc_firewall/stable"
+
+  # Pass values to the module
+  gcp_project_id = var.gcp_project_id
+  gcp_region     = var.gcp_region
+  gcp_zone       = var.gcp_zone
+
+  fwr_network      = module.la_vpc.vpc_network_name
+
+  # Firewall Policy - Repeatable list of objects
+  fwr_rules = [
+    {
+      fwr_name                    = "${module.la_vpc.vpc_network_name}-allow-internal"
+      fwr_description             = "Private internal communication"
+      fwr_source_ranges           = [ "${var.vpcSubnetCidr}" ]
+      fwr_destination_ranges      = null
+      fwr_source_tags             = null
+      fwr_source_service_accounts = null
+      fwr_target_tags             = null 
+      fwr_target_service_accounts = null
+      fwr_priority                = "1000"
+      fwr_direction               = "INGRESS"
+
+      # Allow List
+      allow = [
+        {
+          protocol     = "tcp"
+          ports        = [ "0-65535" ] 
+        },
+        {
+          protocol     = "udp"
+          ports        = [ "0-65535" ] 
+        }
+      ]
+
+      # Deny List
+      deny = []
+
+      log_config = {
+        metadata = "INCLUDE_ALL_METADATA"
+      }
+##    },
+##    {
+##      fwr_name                    = "custom-allow-internal"
+##      fwr_description             = "Private internal communication"
+##      fwr_source_ranges           = [ "${var.vpcSubnetCidr}" ]
+##      fwr_destination_ranges      = null
+##      fwr_source_tags             = null
+##      fwr_source_service_accounts = null
+##      fwr_target_tags             = null 
+##      fwr_target_service_accounts = null
+##      fwr_priority                = "65534"
+##      fwr_direction               = "INGRESS"
+##
+##      # Allow List
+##      allow = [
+##        {
+##          protocol     = "tcp"
+##          ports        = [ "0-65535" ] 
+##        },
+##        {
+##          protocol     = "udp"
+##          ports        = [ "0-65535" ] 
+##        }
+##      ]
+##
+##      # Deny List
+##      deny = []
+##
+##      log_config = {
+##        metadata = "INCLUDE_ALL_METADATA"
+##      }
+    }
+ ]
+
+  ## Firewall depends on existence of Network
+  depends_on = [ module.la_vpc.vpc_network_name ]
+}

--- a/basics/cloud_run/stable/v2/gce.tf
+++ b/basics/cloud_run/stable/v2/gce.tf
@@ -1,0 +1,39 @@
+# Module: Google Compute Engine
+
+module "la_gce" {
+  source = "github.com/CloudVLab/terraform-lab-foundation//basics/gce_instance/dev"
+  # source = "github.com/CloudVLab/terraform-lab-foundation//basics/gce_instance/stable"
+
+  # Pass values to the module
+  gcp_project_id = var.gcp_project_id
+  gcp_region     = var.gcp_region
+  gcp_zone       = var.gcp_zone
+
+  # Customise the GCE instance
+  gce_name            = "cls-vm" 
+  gce_metadata        = null
+  gce_startup_script  = null
+
+  ## Family project override
+  gce_machine_image   = data.google_compute_image.image_family.self_link
+  gce_region          = var.gcp_region 
+  gce_zone            = var.gcp_zone 
+  gce_machine_type    = var.gceMachineType 
+  gce_tags            = ["lab-vm"] 
+  gce_machine_network = module.la_vpc.vpc_subnetwork_name
+
+  gce_assign_external_ip = false 
+  #gce_machine_network    = google_compute_subnetwork.dev_subnet.name
+  #gce_scopes             = ["cloud-platform"] 
+  #gce_service_account    = "default"
+  #gce_startup_script     = "${file("./scripts/lab-init")}"
+}
+
+## Create a Compute Instance 
+## ----------------------------------------------------------------------------
+
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_target_instance
+data "google_compute_image" "image_family" {
+  family  = var.gceMachineImage
+  project = "qwiklabs-resources"
+}

--- a/basics/cloud_run/stable/v2/outputs.tf
+++ b/basics/cloud_run/stable/v2/outputs.tf
@@ -1,0 +1,14 @@
+## --------------------------------------------------------------
+## Custom variable defintions
+## --------------------------------------------------------------
+
+output "ideEditorService" {
+  #  value       = "${google_cloud_run_service.ide.status[0].url}"
+  value       = "${google_cloud_run_v2_service.ide.uri}"
+  description = "URL of the IDE service"
+}
+
+output "ideInstanceName" {
+  value       = "${var.gceInstanceName}"
+  description = "Name of the GCE instance"
+}

--- a/basics/cloud_run/stable/v2/provider.tf
+++ b/basics/cloud_run/stable/v2/provider.tf
@@ -1,0 +1,11 @@
+provider "google" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+  zone    = var.gcp_zone
+}
+
+provider "google-beta" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+  zone    = var.gcp_zone
+}

--- a/basics/cloud_run/stable/v2/runtime.yaml
+++ b/basics/cloud_run/stable/v2/runtime.yaml
@@ -1,0 +1,2 @@
+runtime: terraform
+version: 1.0.1

--- a/basics/cloud_run/stable/v2/variables.tf
+++ b/basics/cloud_run/stable/v2/variables.tf
@@ -1,0 +1,179 @@
+## --------------------------------------------------------------
+## Mandatory variable definitions
+## --------------------------------------------------------------
+
+variable "gcp_project_id" {
+  type        = string
+  description = "The GCP project ID to create resources in."
+}
+
+# Default value passed in
+variable "gcp_region" {
+  type        = string
+  description = "Region to create resources in."
+}
+
+# Default value passed in
+variable "gcp_zone" {
+  type        = string
+  description = "Zone to create resources in."
+}
+
+## --------------------------------------------------------------
+## Output variable definitions - Override from Custom Properties 
+## --------------------------------------------------------------
+## Ensure these values are defined in Qwiklabs.yaml
+
+# with the same name for any lab that uses this script.
+variable "gcp_username" {
+  type        = string
+  description = "Name of Qwiklabs user"
+  default     = "tester"
+}
+
+## --------------------------------------------------------------
+## Custom variable definitions - Override from Custom Properties
+## --------------------------------------------------------------
+# Custom properties with defaults 
+variable "vpcNetworkName" {
+  type        = string
+  description = "Custom network"
+  default     = "dev-network"
+}
+
+# Custom properties with defaults 
+variable "vpcSubnetName" {
+  type        = string
+  description = "Custom network"
+  default     = "dev-subnetwork"
+}
+
+# Custom properties with defaults 
+variable "vpcDescription" {
+  type        = string
+  description = "Custom network"
+  default     = "Lab custom network"
+}
+
+# Custom properties with defaults 
+variable "vpcSubnetCidr" {
+  type    = string
+  default = "10.1.0.0/24"
+}
+
+# Custom properties with defaults 
+variable "vpcDefaultCidr" {
+  type    = string
+  default = "10.128.0.0/9"
+}
+
+# Custom properties with defaults 
+variable "vpcConnectorMachineType" {
+  type        = string 
+  description = "VPC Access Connector Machine Type"
+  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  default     = "e2-micro" 
+}
+
+variable "gcrIDEService" {
+  type        = string
+  description = "Name of the proxy service"
+  default     = "ide-service"
+}
+
+variable "gcrRegion" {
+  type        = string
+  description = "GCE virtual machine image family"
+  default     = "us-central1"
+}
+
+variable "gceMachineImage" {
+  type        = string
+  description = "GCE virtual machine image family"
+  default     = "test-cloud-codeserver"
+#  default     = "test-flutter-codeserver"
+#  default     = "cloud-code-codeserver"
+#  default     = "debian-cloud/debian-10"
+}
+
+variable "gceProjectMachineImage" {
+  type        = string
+  description = "Project hosting the image family"
+  default     = "qwiklabs-resources"
+}
+
+variable "gceInstanceName" {
+  type        = string
+  description = "GCE virtual machine image family"
+  default     = "cloudlearningservices"
+}
+
+# Custom properties with defaults 
+variable "gceInstanceZone" {
+  type        = string 
+  description = "Zone to create resources in."
+  default     = "us-central1-f" 
+}
+
+# Custom properties with defaults 
+variable "gceInstanceTags" {
+  type        = list(string)
+  description = "GCE virtual machine tags"
+  default     = ["lab-vm"]
+}
+
+# Custom properties with defaults 
+variable "gceMachineType" {
+  type        = string 
+  description = "Machine type to use for GCE"
+  default     = "e2-standard-2" 
+}
+
+# Custom properties with defaults 
+variable "gceInstanceNetwork" {
+  type        = string
+  description = "GCE virtual machine network"
+  default     = "default"
+}
+
+# Custom properties with defaults 
+variable "gceInstanceScope" {
+  type        = list(string)
+  description = "GCE service account scope"
+  default     = ["cloud-platform"]
+}
+
+variable "isPrivateCluster" {
+  default = true
+  description = "True to spin up a private, secure cluster. False to spin up a public cluster."
+}
+
+variable "isCustomNetwork" {
+  default = true
+  description = "True to utilize custom network resources. False to switch to default network."
+}
+
+
+## GKE Settings
+#
+
+# Custom properties with defaults 
+variable "gkeClusterName" {
+  type        = string
+  description = "GKE Cluster name."
+  default     = "dev-cluster" 
+}
+
+# Custom properties with defaults 
+variable "gkeMasterIPv4CIDRBlock" {
+  type    = string
+  default = "172.23.0.0/28"
+}
+
+# Custom properties with defaults 
+variable "gkeRegion" {
+  type        = string 
+  description = "Region to create resources in."
+  default     = "us-central1" 
+}
+

--- a/basics/cloud_run/stable/v2/vpc.tf
+++ b/basics/cloud_run/stable/v2/vpc.tf
@@ -1,0 +1,25 @@
+# Module: Virtual Private Cloud
+
+module "la_vpc" {
+  ## NOTE: When changing the source parameter, `terraform init` is required
+
+  ## Local Modules - working
+  ## Module subdirectory needs to be defined within the TF directory
+  # source = "./basics/vpc_network/stable"
+
+  ## REMOTE: GitHub (Public) access - working
+  source = "github.com/CloudVLab/terraform-lab-foundation//basics/vpc_network/stable"
+
+  # Pass values to the module
+  gcp_project_id = var.gcp_project_id
+  gcp_region     = var.gcp_region
+  gcp_zone       = var.gcp_zone
+
+  # Customise the VPC 
+  vpc_network             = var.vpcNetworkName 
+  vpc_network_description = var.vpcDescription 
+  vpc_subnet              = var.vpcSubnetName 
+  vpc_region              = var.gcp_region
+  vpc_subnet_cidr         = var.vpcSubnetCidr 
+}
+


### PR DESCRIPTION
Cloud Run

Start the migration away from Cloud Run v1 to Cloud Run v2.

-  [ ] Added Stable V1 and V2 folder to split out existing functionality
-  [ ] Stable V1 - Cloud Run Gen 1
-  [ ] Stable V2 - Cloud Run Gen 2