### PR TITLE
Tlf workbench

### DIFF
--- a/basics/iam_role_bind/stable/main.tf
+++ b/basics/iam_role_bind/stable/main.tf
@@ -4,7 +4,7 @@
 resource "google_service_account" "service_account" {
   account_id   = var.iam_sa_name 
   description  = var.iam_sa_description 
-  display_name = var.iam_sa 
+  display_name = var.iam_sa_name 
 }
 
 ## https://www.terraform.io/language/values/locals#using-local-values

--- a/basics/iam_role_bind/stable/main.tf
+++ b/basics/iam_role_bind/stable/main.tf
@@ -4,7 +4,7 @@
 resource "google_service_account" "service_account" {
   account_id   = var.iam_sa_name 
   description  = var.iam_sa_description 
-  display_name = var.iam_sa_name 
+  display_name = var.iam_sa_display
 }
 
 ## https://www.terraform.io/language/values/locals#using-local-values

--- a/basics/iam_role_bind/stable/variables.tf
+++ b/basics/iam_role_bind/stable/variables.tf
@@ -49,6 +49,20 @@ variable "iam_sa_description" {
 }
 
 # with the same name for any lab that uses this script.
+variable "iam_sa_display" {
+  type        = string
+  description = "Display name for the SA"
+  default     = "tester-qwiklabs account" 
+}
+
+# with the same name for any lab that uses this script.
+variable "iam_sa" {
+  type        = string
+  description = "Display name for the SA"
+  default     = "tester-qwiklabs account" 
+}
+
+# with the same name for any lab that uses this script.
 variable "iam_role" {
   type        = string
   description = "Role to bind to the user account"


### PR DESCRIPTION
Fix: missing SA display name

- [x] Add missing variable value.
- [x] Set display name value as a variable.

## Added the following for Backward compatibility
```terraform
variable "iam_sa_display" {
  type        = string
  description = "Display name for the SA"
  default     = "tester-qwiklabs account" 
}

# with the same name for any lab that uses this script.
variable "iam_sa" {
  type        = string
  description = "Display name for the SA"
  default     = "tester-qwiklabs account" 
}
```