### PR TITLE
use Workbench Instances instead of User-Managed Instances for the generative-ai solution

### DIFF
--- a/solutions/generative-ai/stable/main.tf
+++ b/solutions/generative-ai/stable/main.tf
@@ -108,24 +108,23 @@ resource "google_storage_bucket_object" "notebook_config_script" {
   Create Vertex AI Notebook
 */
 
-resource "google_notebooks_instance" "genai_notebook" {
+resource "google_workbench_instance" "genai_notebook" {
 
   name               = var.sme_notebook_name
   project            = var.gcp_project_id
   location           = var.gcp_zone
-  machine_type       = var.sme_machine_type
-  install_gpu_driver = false
-  metadata = {
-    proxy-mode = "service_account"
-    terraform  = "true"
+  
+  gce_setup {
+    machine_type = "e2-standard-2"
+    vm_image {
+      project = "cloud-notebooks-managed"
+      family  = "workbench-instances"
+    }
+    metadata = {
+      post-startup-script = "gs://${var.gcp_project_id}-labconfig-bucket/notebook_config.sh"
+    }
   }
-
-  container_image {
-    repository = "gcr.io/deeplearning-platform-release/base-cpu"
-    tag = "latest"
-  }
-
-  post_startup_script = "gs://${var.gcp_project_id}-labconfig-bucket/notebook_config.sh"
+  
 
   depends_on = [google_project_service.gcp_services, google_storage_bucket_object.notebook_config_script]
 }


### PR DESCRIPTION
Modify the terraform script to create a Workbench Instance, instead of a User-Managed Instance.

Reference:
- [Latest tf docs on deploying Vertex AI Workbench Instances](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/workbench_instance)
- `post-startup-script` is used within the `metadata` field: [documentation](https://cloud.google.com/vertex-ai/docs/workbench/instances/manage-metadata#keys)