### PR TITLE
Service Identity - Expose member value

### DIFF
--- a/basics/identity_service/dev/outputs.tf
+++ b/basics/identity_service/dev/outputs.tf
@@ -8,10 +8,5 @@ output "wait_identity_delay" {
 
 output "service_account_emails" {
   value = { for k, v in google_project_service_identity.tlf : k => v.member }
-  description = "Map of service names to their corresponding service account emails"
+  description = "Map of service names key to their corresponding service account property value"
 }
-
-## output "service_account_member" {
-##   value = google_project_service_identity.tlf[tolist(google_project_service_identity.tlf)[0]].member
-##   description = "Service identity member service account"
-## }

--- a/basics/identity_service/dev/outputs.tf
+++ b/basics/identity_service/dev/outputs.tf
@@ -1,6 +1,10 @@
 ## --------------------------------------------------------------
-## Custom variable defintions
+## Custom variable definitions
 ## --------------------------------------------------------------
 output "wait_identity_delay" {
   value = time_sleep.wait_identity_delay.id
+}
+
+output "service_account_member" {
+  value = google_project_service_identity.tlf.member
 }

--- a/basics/identity_service/dev/outputs.tf
+++ b/basics/identity_service/dev/outputs.tf
@@ -7,6 +7,6 @@ output "wait_identity_delay" {
 }
 
 output "service_account_member" {
-  value = tolist(google_project_service_identity.tlf)[0].member
+  value = google_project_service_identity.tlf[tolist(google_project_service_identity.tlf)[0]].member
   description = "Service identity member service account"
 }

--- a/basics/identity_service/dev/outputs.tf
+++ b/basics/identity_service/dev/outputs.tf
@@ -3,8 +3,10 @@
 ## --------------------------------------------------------------
 output "wait_identity_delay" {
   value = time_sleep.wait_identity_delay.id
+  description = "Custom delay for API to be enabled"
 }
 
 output "service_account_member" {
-  value = google_project_service_identity.tlf[0].member
+  value = tolist(google_project_service_identity.tlf)[0].member
+  description = "Service identity member service account"
 }

--- a/basics/identity_service/dev/outputs.tf
+++ b/basics/identity_service/dev/outputs.tf
@@ -6,7 +6,12 @@ output "wait_identity_delay" {
   description = "Custom delay for API to be enabled"
 }
 
-output "service_account_member" {
-  value = google_project_service_identity.tlf[tolist(google_project_service_identity.tlf)[0]].member
-  description = "Service identity member service account"
+output "service_account_emails" {
+  value = { for k, v in google_project_service_identity.tlf : k => v.member }
+  description = "Map of service names to their corresponding service account emails"
 }
+
+## output "service_account_member" {
+##   value = google_project_service_identity.tlf[tolist(google_project_service_identity.tlf)[0]].member
+##   description = "Service identity member service account"
+## }

--- a/basics/identity_service/dev/outputs.tf
+++ b/basics/identity_service/dev/outputs.tf
@@ -6,5 +6,5 @@ output "wait_identity_delay" {
 }
 
 output "service_account_member" {
-  value = google_project_service_identity.tlf.member
+  value = google_project_service_identity.tlf[0].member
 }


### PR DESCRIPTION
Add: Service Identity output variable.

- [x] Custom Duration
- [x] Member variable i.e. Service Account.

Value will be presented in the following format:
```json
    "service_account_member": {
      "sensitive": false,
      "type": [
        "object",
        {
          "aiplatform.googleapis.com": "string"
        }
      ],
      "value": {
        "aiplatform.googleapis.com": "serviceAccount:service-179770616443@gcp-sa-aiplatform.iam.gserviceaccount.com"
      }
    },
```