### PR TITLE
hotfix: gce instance variable default should be null

### DIFF
--- a/basics/gce_instance/stable/variables.tf
+++ b/basics/gce_instance/stable/variables.tf
@@ -42,19 +42,18 @@ variable "gce_name" {
 ## --------------------------------------------------------------
 ## Custom variable definitions - Override from Custom Properties
 ## --------------------------------------------------------------
-
 # Custom properties with defaults 
 variable "gce_region" {
-  type        = string 
+  type        = string
   description = "Region to create resources in."
-  default     = "us-central1" 
+  default     = null
 }
 
 # Custom properties with defaults 
 variable "gce_zone" {
-  type        = string 
+  type        = string
   description = "Zone to create resources in."
-  default     = "us-central1-f" 
+  default     = null 
 }
 
 # Custom properties with defaults 


### PR DESCRIPTION
Module: GCE Instance
Channel: Stable

Per conversation with QL Eng. It looks like the stable channel logic has a bug.
Amend the `stable` channel variable to use the same default as the `V1 method. Code expects a null is as default to allow the user to default to the `var.gcp_region` or `var.gcp_zone`.