### PR TITLE
TLF CF: CR/AR Migration issue

### DIFF
--- a/basics/cloud_function/dev/main.tf
+++ b/basics/cloud_function/dev/main.tf
@@ -13,11 +13,11 @@ resource "google_storage_bucket" "bucket" {
 }
 
 resource "google_storage_bucket_object" "archive" {
-  name   = var.gcf_archive_object 
+  name   = var.gcf_archive_object
   bucket = google_storage_bucket.bucket.name
-  source = var.gcf_archive_source 
+  source = var.gcf_archive_source
 
-  depends_on = [ google_storage_bucket.bucket ]
+  depends_on = [google_storage_bucket.bucket]
 }
 
 #
@@ -26,28 +26,39 @@ resource "google_storage_bucket_object" "archive" {
 #
 ## NEW Module: Cloud Function
 
+data "google_project" "project" {
+  project_id = var.gcp_project_id
+}
+
+locals {
+  #  PROJECT_NUMBER-compute@developer.gserviceaccount.com
+  service_account = "serviceAccount:${data.google_project.project.number}-$compute@developer.gserviceaccount.com"
+}
+
 resource "google_cloudfunctions_function" "custom_function" {
-  name                         = var.gcf_name 
-  project                      = var.gcp_project_id
-  region                       = var.gcp_region
-  description                  = var.gcf_description 
-  runtime                      = var.gcf_runtime
+  name        = var.gcf_name
+  project     = var.gcp_project_id
+  region      = var.gcp_region
+  description = var.gcf_description
+  runtime     = var.gcf_runtime
 
   ## source_archive_bucket = var.gcf_target_bucket 
   ## source_archive_object = var.gcf_archive_source
-  source_archive_bucket        = google_storage_bucket.bucket.name
-  source_archive_object        = google_storage_bucket_object.archive.name
-  entry_point                  = var.gcf_entry_point 
+  source_archive_bucket = google_storage_bucket.bucket.name
+  source_archive_object = google_storage_bucket_object.archive.name
+  entry_point           = var.gcf_entry_point
 
   ## Ref: CR/AF Migration 
-  available_memory_mb          = var.gcf_available_mb 
-  docker_registry              = var.gcf_registry
-  timeout                      = var.gcf_timeout 
-  trigger_http                 = var.gcf_trigger_http 
-  https_trigger_security_level = var.gcf_trigger_security 
+  available_memory_mb = var.gcf_available_mb
+  # docker_registry              = var.gcf_registry
+  timeout                      = var.gcf_timeout
+  trigger_http                 = var.gcf_trigger_http
+  https_trigger_security_level = var.gcf_trigger_security
   environment_variables        = var.gcf_environment_variables
 
-  depends_on                   = [ google_storage_bucket_object.archive ]
+  # b/374612344 - Gen 1 uses appspot as service SA + compute dev as Build SA
+  service_account_email = local.service_account
+  depends_on            = [google_storage_bucket_object.archive]
 }
 
 #
@@ -62,6 +73,6 @@ resource "google_cloudfunctions_function_iam_member" "invoker" {
   project        = var.gcp_project_id
   region         = var.gcp_region
   cloud_function = google_cloudfunctions_function.custom_function.name
-  role           = var.gcf_role_bind 
-  member         = var.gcf_member_account 
+  role           = var.gcf_role_bind
+  member         = var.gcf_member_account
 }

--- a/basics/cloud_function/dev/main.tf
+++ b/basics/cloud_function/dev/main.tf
@@ -57,7 +57,7 @@ resource "google_cloudfunctions_function" "custom_function" {
   environment_variables        = var.gcf_environment_variables
 
   # b/374612344 - Gen 1 uses appspot as service SA + compute dev as Build SA
-  service_account_email = local.service_account
+  service_account_email = var.gcf_service_account == null ? null : var.gcf_service_account 
   depends_on            = [google_storage_bucket_object.archive]
 }
 

--- a/basics/cloud_function/dev/main.tf
+++ b/basics/cloud_function/dev/main.tf
@@ -32,7 +32,7 @@ data "google_project" "project" {
 
 locals {
   #  PROJECT_NUMBER-compute@developer.gserviceaccount.com
-  service_account = "serviceAccount:${data.google_project.project.number}-$compute@developer.gserviceaccount.com"
+  service_account = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
 }
 
 resource "google_cloudfunctions_function" "custom_function" {

--- a/basics/cloud_function/dev/main.tf
+++ b/basics/cloud_function/dev/main.tf
@@ -57,7 +57,7 @@ resource "google_cloudfunctions_function" "custom_function" {
   environment_variables        = var.gcf_environment_variables
 
   # b/374612344 - Gen 1 uses appspot as service SA + compute dev as Build SA
-  service_account_email = var.gcf_service_account == null ? null : var.gcf_service_account 
+  service_account_email = var.gcf_service_account_email == null ? null : var.gcf_service_account_email 
   depends_on            = [google_storage_bucket_object.archive]
 }
 

--- a/basics/cloud_function/dev/main.tf
+++ b/basics/cloud_function/dev/main.tf
@@ -50,7 +50,7 @@ resource "google_cloudfunctions_function" "custom_function" {
 
   ## Ref: CR/AF Migration 
   available_memory_mb = var.gcf_available_mb
-  # docker_registry              = var.gcf_registry
+  docker_registry              = var.gcf_registry
   timeout                      = var.gcf_timeout
   trigger_http                 = var.gcf_trigger_http
   https_trigger_security_level = var.gcf_trigger_security

--- a/basics/cloud_function/dev/variables.tf
+++ b/basics/cloud_function/dev/variables.tf
@@ -110,8 +110,8 @@ variable "gcf_environment_variables" {
 variable "gcf_registry" {
   type        = string
   description = "Registry type to use."
-  default     = "ARTIFACT_REGISTRY"
-  # default     = "CONTAINER_REGISTRY"
+  # default     = "ARTIFACT_REGISTRY"
+  default     = "CONTAINER_REGISTRY"
 }
 
 variable "gcf_available_mb" {

--- a/basics/cloud_function/dev/variables.tf
+++ b/basics/cloud_function/dev/variables.tf
@@ -67,6 +67,14 @@ variable "gcf_runtime" {
   default     = "nodejs16"
 }
 
+# Default value passed in
+variable "gcf_service_account" {
+  type        = string
+  description = "Cloud Function Service Account."
+  default     = null 
+}
+
+
 variable "gcf_target_bucket" {
   type        = string
   description = "Target bucket to upload source code."

--- a/basics/cloud_function/dev/variables.tf
+++ b/basics/cloud_function/dev/variables.tf
@@ -68,9 +68,9 @@ variable "gcf_runtime" {
 }
 
 # Default value passed in
-variable "gcf_service_account" {
+variable "gcf_service_account_email" {
   type        = string
-  description = "Cloud Function Service Account."
+  description = "Cloud Function Service Account Email."
   default     = null 
 }
 

--- a/basics/cloud_function/dev/variables.tf
+++ b/basics/cloud_function/dev/variables.tf
@@ -95,33 +95,33 @@ variable "gcf_environment_variables" {
   type = map(string)
 
   default = {
-    PROJECT_ID = "undefined" 
+    PROJECT_ID = "undefined"
   }
 }
 
 variable "gcf_registry" {
   type        = string
   description = "Registry type to use."
-  # default     = "ARTIFACT_REGISTRY"
-  default     = "CONTAINER_REGISTRY"
+  default     = "ARTIFACT_REGISTRY"
+  # default     = "CONTAINER_REGISTRY"
 }
 
 variable "gcf_available_mb" {
-  type        = number 
+  type        = number
   description = "Amount of memory to allocate."
   default     = 128
 }
 
 variable "gcf_timeout" {
-  type        = number 
+  type        = number
   description = "Cloud Function timeout delay, defaults to 60s."
-  default     = 60 
+  default     = 60
 }
 
 variable "gcf_trigger_http" {
-  type        = bool 
+  type        = bool
   description = "Trigger on http request."
-  default     = true 
+  default     = true
 }
 
 variable "gcf_trigger_security" {


### PR DESCRIPTION
Work to resolve intermittent errors when provisioning Cloud Functions Gen 1 with the TLF module.
The issue appears to relate to how CR/AR is being routed. CR is routed to AR automatically, so the fix appears to be to set the registry default to CR.

Ref: https://buganizer.corp.google.com/issues/375120549

- [x] Make Container Registry the default for Cloud Functions Gen 1.
- [x] Add Service Account override.
- [x] Created ticket to revisit in 2025 [b/375120549](https://buganizer.corp.google.com/issues/375120549)