### PR TITLE
Proxy Workbench: Migration to Cloud Storage + Variable to disable external IP

### DIFF
--- a/solutions/proxy_vertex_workbench/example/main.tf
+++ b/solutions/proxy_vertex_workbench/example/main.tf
@@ -1,26 +1,8 @@
 # ------------------ Proxy: Vertex Notebook 
-# ------------------ Module Definition 
-#
-
-# Local:  modules/[channel]
-# Remote: github.com://CloudVLab/terraform-lab-foundation//[module]/[channel]
-
-# Solution: IDE environment 
-# Local:  modules/stable
-# Remote: github.com/CloudVLab/terraform-lab-foundation//solutions/proxy_vertex_workbench/stable
-
 # Output Value(s):
 # - vertex_notebook_url: URL of Browser Service
 
 module "la_vertex_workbench" {
-  ## NOTE: When changing the `source` parameter
-  ## `terraform init` is required
-
-  ## Local Modules - working
-  ## Module subdirectory needs to be defined within the TF directory
-  #source = "./solutions/vertex_proxy_workbench/dev"
-
-  ## REMOTE: GitHub (Public) access - working 
   ## source = "github.com/CloudVLab/terraform-lab-foundation//solutions/proxy_vertex_workbench/stable/v1"
   source = "gcs::https://www.googleapis.com/storage/v1/terraform-lab-foundation/solutions/proxy_vertex_workbench/stable/v1"
 
@@ -33,4 +15,3 @@ module "la_vertex_workbench" {
   ## https://cloud.google.com/vertex-ai/docs/workbench/user-managed/images
   ## gcePostStartupScript = "https://storage.googleapis.com/spls/[LAB_ID]/lab-init.sh"
 }
-

--- a/solutions/proxy_vertex_workbench/stable/v1/api.tf
+++ b/solutions/proxy_vertex_workbench/stable/v1/api.tf
@@ -13,7 +13,8 @@ resource "time_sleep" "wait_api_delay" {
 # ----------------------------------------------------------------------------
 module "la_api_batch" {
   ## source = "github.com/CloudVLab/terraform-lab-foundation//basics/api_service/dev"
-  source = "github.com/CloudVLab/terraform-lab-foundation//basics/api_service/stable/v1"
+  ## source = "github.com/CloudVLab/terraform-lab-foundation//basics/api_service/stable/v1"
+  source = "gcs::https://www.googleapis.com/storage/v1/terraform-lab-foundation/basics/api_service/stable/v1"
 
   # Pass values to the module
   gcp_project_id = var.gcp_project_id

--- a/solutions/proxy_vertex_workbench/stable/v1/cr.tf
+++ b/solutions/proxy_vertex_workbench/stable/v1/cr.tf
@@ -1,6 +1,7 @@
 # Module: Cloud Run Gen v2 
 module "la_cloud_run_v2" {
-  source = "github.com/CloudVLab/terraform-lab-foundation//basics/cloud_run/stable/v2"
+  ## source = "github.com/CloudVLab/terraform-lab-foundation//basics/cloud_run/stable/v2"
+  source = "gcs::https://www.googleapis.com/storage/v1/terraform-lab-foundation/basics/cloud_run/stable/v2"
 
   # Pass values to the module
   gcp_project_id = var.gcp_project_id

--- a/solutions/proxy_vertex_workbench/stable/v1/fw.tf
+++ b/solutions/proxy_vertex_workbench/stable/v1/fw.tf
@@ -6,7 +6,8 @@ module "la_fw" {
   # source = "./basics/vpc_firewall/stable"
 
   ## REMOTE: GitHub (Public) access - working
-  source = "github.com/CloudVLab/terraform-lab-foundation//basics/vpc_firewall/stable"
+  ## source = "github.com/CloudVLab/terraform-lab-foundation//basics/vpc_firewall/stable"
+  source = "gcs::https://www.googleapis.com/storage/v1/terraform-lab-foundation/basics/vpc_firewall/stable"
 
   # Pass values to the module
   gcp_project_id = var.gcp_project_id

--- a/solutions/proxy_vertex_workbench/stable/v1/sa.tf
+++ b/solutions/proxy_vertex_workbench/stable/v1/sa.tf
@@ -1,7 +1,8 @@
 # Create Service Account and Bind Role
 module "la_role_bind" {
   ## REMOTE: GitHub (Public) access - working 
-  source = "github.com/CloudVLab/terraform-lab-foundation//basics/iam_role_bind/stable"
+  ## source = "github.com/CloudVLab/terraform-lab-foundation//basics/iam_role_bind/stable"
+  source = "gcs::https://www.googleapis.com/storage/v1/terraform-lab-foundation/basics/iam_role_bind/stable"
 
   ## Exchange values between Qwiklabs and Module
   gcp_project_id = var.gcp_project_id

--- a/solutions/proxy_vertex_workbench/stable/v1/variables.tf
+++ b/solutions/proxy_vertex_workbench/stable/v1/variables.tf
@@ -76,7 +76,7 @@ variable "gcrMemberPermission" {
 variable "gceInstanceName" {
   type        = string
   description = "Name of virtual machine."
-  default     = "cloudlearningservices"
+  default     = "cls-vertex-workbench"
 }
 
 # Custom properties with defaults 
@@ -90,7 +90,7 @@ variable "gceInstanceZone" {
 variable "gceInstanceTags" {
   type        = list(string)
   description = "GCE virtual machine tags"
-  default     = ["lab-vm"]
+  default     = [ "cls", "lab-vm", "http-server", "https-server" ]
 }
 
 variable "gceImageProject" {
@@ -117,6 +117,13 @@ variable "gceInstanceNetwork" {
   type        = string
   description = "GCE virtual machine network"
   default     = "default"
+}
+
+# Custom properties with defaults 
+variable "gceDisableExternalIp" {
+  type        = bool 
+  description = "GCE disable external IP"
+  default     = true 
 }
 
 # Custom properties with defaults 

--- a/solutions/proxy_vertex_workbench/stable/v1/vpc.tf
+++ b/solutions/proxy_vertex_workbench/stable/v1/vpc.tf
@@ -6,7 +6,8 @@ module "la_vpc" {
   # source = "./basics/vpc_network/stable"
 
   ## REMOTE: GitHub (Public) access - working
-  source = "github.com/CloudVLab/terraform-lab-foundation//basics/vpc_network/stable"
+  ## source = "github.com/CloudVLab/terraform-lab-foundation//basics/vpc_network/stable"
+  source = "gcs::https://www.googleapis.com/storage/v1/terraform-lab-foundation/basics/vpc_network/stable"
 
   # Pass values to the module
   gcp_project_id = var.gcp_project_id

--- a/solutions/proxy_vertex_workbench/stable/v1/workbench.tf
+++ b/solutions/proxy_vertex_workbench/stable/v1/workbench.tf
@@ -7,8 +7,8 @@ module "la_vai_workbench" {
   # source = "./basics/vai_workbench/stable"
 
   ## REMOTE: GitHub (Public) access - working 
-  source = "github.com/CloudVLab/terraform-lab-foundation//basics/vai_workbench/stable"
-  ## source = "gcs::https://www.googleapis.com/storage/v1/terraform-lab-foundation/basics/vai_workbench/stable"
+  ## source = "github.com/CloudVLab/terraform-lab-foundation//basics/vai_workbench/stable"
+  source = "gcs::https://www.googleapis.com/storage/v1/terraform-lab-foundation/basics/vai_workbench/stable/v1"
 
   ## Exchange values between Qwiklabs and Module
   gcp_project_id = var.gcp_project_id
@@ -16,14 +16,14 @@ module "la_vai_workbench" {
   gcp_zone       = var.gcp_zone 
 
   ## Custom Properties
-  vai_workbench_name  = "cls-vertex-workbench" 
+  vai_workbench_name  =  var.gceInstanceName 
   vai_machine_subnet  = module.la_vpc.vpc_subnet_self_link 
-  # vai_tags            = [ "cls", "lab-vm", "http-server", "https-server" ]
-
+  # vai_tags            = var.gceInstanceTags 
   # vai_machine_subnet      = module.la_vpc.vpc_subnetwork_name 
   # vai_machine_network     = module.la_vpc.vpc_network_name 
   # vai_machine_network     = module.la_vpc.vpc_network_self_link
   vai_post_startup_script = var.gcePostStartupScript  
+  vai_disable_public_ip   = var.gceDisableExternalIp
 
   # Give the JIT API time to be enabled
   depends_on = [ time_sleep.wait_api_delay ]


### PR DESCRIPTION
Proxy Vertex AI Workbench

- [x] Updated sources to use Cloud Storage as default
- [x] Remove hard coding of values and replace with variables
- [x] Fix: Disable external IP on GCE instance by default for Proxy environment