### PR TITLE
Revert "Add: google-beta fix - Basics"

### DIFF
--- a/basics/cloud_run/example/versions.tf
+++ b/basics/cloud_run/example/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       # https://registry.terraform.io/providers/hashicorp/google/latest
-      version = ">=5.6.0"
+      version = "5.6.0"
     }
-##    google-beta = {
-##      # https://registry.terraform.io/providers/hashicorp/google-beta/latest
-##      version = "5.6.0"
-##    }
+    google-beta = {
+      # https://registry.terraform.io/providers/hashicorp/google-beta/latest
+      version = "5.6.0"
+    }
   }
 }

--- a/basics/cloud_run/stable/v2/provider.tf
+++ b/basics/cloud_run/stable/v2/provider.tf
@@ -4,8 +4,8 @@ provider "google" {
   zone    = var.gcp_zone
 }
 
-## provider "google-beta" {
-##   project = var.gcp_project_id
-##   region  = var.gcp_region
-##   zone    = var.gcp_zone
-## }
+provider "google-beta" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+  zone    = var.gcp_zone
+}

--- a/basics/firebase_project/stable/main.tf
+++ b/basics/firebase_project/stable/main.tf
@@ -13,7 +13,7 @@ module "la_api_batch" {
 
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/firebase_project.html
 resource "google_firebase_project" "default" {
-#    provider = google-beta
+    provider = google-beta
     project  = var.gcp_project_id 
     depends_on = [ module.la_api_batch ]
 }

--- a/basics/gke_autopilot/stable/gke_autopilot.tf
+++ b/basics/gke_autopilot/stable/gke_autopilot.tf
@@ -8,7 +8,7 @@
 
 # GKE cluster
 resource "google_container_cluster" "tfer-gke" {
-#  provider    = google-beta
+  provider    = google-beta
   project     = var.gcp_project_id
   name        = var.gkeClusterName
   location    = var.gcp_region

--- a/basics/gke_autopilot/stable/provider.tf
+++ b/basics/gke_autopilot/stable/provider.tf
@@ -4,8 +4,8 @@ provider "google" {
   zone    = var.gcp_zone
 }
 
-## provider "google-beta" {
-##   project = var.gcp_project_id
-##   region  = var.gcp_region
-##   zone    = var.gcp_zone
-## }
+provider "google-beta" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+  zone    = var.gcp_zone
+}

--- a/basics/gke_cluster/dev/main.tf
+++ b/basics/gke_cluster/dev/main.tf
@@ -8,7 +8,7 @@
 
 # GKE cluster
 resource "google_container_cluster" "tfer-gke" {
-#  provider = google-beta
+  provider = google-beta
   project  = var.gcp_project_id 
   name     = var.gkeClusterName
   location = var.gcp_zone 

--- a/basics/gke_cluster/dev/provider.tf
+++ b/basics/gke_cluster/dev/provider.tf
@@ -4,8 +4,8 @@ provider "google" {
   zone    = var.gcp_zone
 }
 
-## provider "google-beta" {
-##   project = var.gcp_project_id
-##   region  = var.gcp_region
-##   zone    = var.gcp_zone
-## }
+provider "google-beta" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+  zone    = var.gcp_zone
+}

--- a/basics/gke_cluster/stable/main.tf
+++ b/basics/gke_cluster/stable/main.tf
@@ -8,7 +8,7 @@
 
 # GKE cluster
 resource "google_container_cluster" "primary" {
-#  provider = google-beta
+  provider = google-beta
   name     = var.gke_cluster_name
   location = var.gke_location
   

--- a/basics/gke_cluster/stable/provider.tf
+++ b/basics/gke_cluster/stable/provider.tf
@@ -4,8 +4,8 @@ provider "google" {
   zone    = var.gcp_zone
 }
 
-## provider "google-beta" {
-##   project = var.gcp_project_id
-##   region  = var.gcp_region
-##   zone    = var.gcp_zone
-## }
+provider "google-beta" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+  zone    = var.gcp_zone
+}

--- a/basics/gke_node_pool/stable/provider.tf
+++ b/basics/gke_node_pool/stable/provider.tf
@@ -4,8 +4,8 @@ provider "google" {
   zone    = var.gcp_zone
 }
 
-## provider "google-beta" {
-##   project = var.gcp_project_id
-##   region  = var.gcp_region
-##   zone    = var.gcp_zone
-## }
+provider "google-beta" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+  zone    = var.gcp_zone
+}

--- a/basics/gke_standard/preview/main.tf
+++ b/basics/gke_standard/preview/main.tf
@@ -7,7 +7,7 @@
 
 # GKE cluster
 resource "google_container_cluster" "primary" {
-#  provider    = google-beta
+  provider    = google-beta
   name        = var.gkeClusterName
   location    = var.gkeLocation
   description = var.gkeDescription 

--- a/basics/gke_standard/preview/provider.tf
+++ b/basics/gke_standard/preview/provider.tf
@@ -4,8 +4,8 @@ provider "google" {
   zone    = var.gcp_zone
 }
 
-## provider "google-beta" {
-##   project = var.gcp_project_id
-##   region  = var.gcp_region
-##   zone    = var.gcp_zone
-## }
+provider "google-beta" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+  zone    = var.gcp_zone
+}

--- a/basics/gke_standard/stable/main.tf
+++ b/basics/gke_standard/stable/main.tf
@@ -7,7 +7,7 @@
 
 # GKE cluster
 resource "google_container_cluster" "tfer-gke" {
-#  provider    = google-beta
+  provider    = google-beta
   project     = var.gcp_project_id
   name        = var.gkeClusterName
   location    = var.gcp_zone

--- a/basics/gke_standard/stable/provider.tf
+++ b/basics/gke_standard/stable/provider.tf
@@ -4,8 +4,8 @@ provider "google" {
   zone    = var.gcp_zone
 }
 
-## provider "google-beta" {
-##   project = var.gcp_project_id
-##   region  = var.gcp_region
-##   zone    = var.gcp_zone
-## }
+provider "google-beta" {
+  project = var.gcp_project_id
+  region  = var.gcp_region
+  zone    = var.gcp_zone
+}

--- a/basics/vai_workbench/example/versions.tf
+++ b/basics/vai_workbench/example/versions.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     google = {
       # https://registry.terraform.io/providers/hashicorp/google/latest
-      version = ">=5.22.0"
+      version = "5.22.0"
     }
-##     google-beta = {
-##       # https://registry.terraform.io/providers/hashicorp/google-beta/latest
-##       version = "5.22.0"
-##     }
+    google-beta = {
+      # https://registry.terraform.io/providers/hashicorp/google-beta/latest
+      version = "5.22.0"
+    }
   }
 }

--- a/basics/vpc_connector/stable/main.tf
+++ b/basics/vpc_connector/stable/main.tf
@@ -1,34 +1,34 @@
-## # Reference:
-## # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vpc_access_connector
-## 
-## # Enable the vpc access service
-## resource "google_project_service" "vpcaccess-api" {
-##   project = var.gcp_project_id
-##   service = "vpcaccess.googleapis.com"
-## 
-##   timeouts {
-##     create = "30m"
-##     update = "40m"
-##   }
-## 
-##   # disable_dependent_services = true
-## }
-## 
-## resource "google_vpc_access_connector" "connector" {
-##   provider       = google-beta
-##   name           = "ideconn"
-##   region         = var.gcp_region
-##   #network       = google_compute_network.dev_network.name
-##   network        = var.sva_network 
-##   #ip_cidr_range = "10.8.0.0/28"
-##   ip_cidr_range  = var.sva_subnet_cidr 
-## 
-##   # Note: valid options: f1-micro, e2-micro, e2-standard-4
-##   machine_type = var.sva_connector_machine_type
-## 
-##   depends_on = [
-##     # google_project_service.vpcaccess-api, google_compute_network.dev_network
-##     google_project_service.vpcaccess-api
-##   ]
-## }
-## 
+# Reference:
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vpc_access_connector
+
+# Enable the vpc access service
+resource "google_project_service" "vpcaccess-api" {
+  project = var.gcp_project_id
+  service = "vpcaccess.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  # disable_dependent_services = true
+}
+
+resource "google_vpc_access_connector" "connector" {
+  provider       = google-beta
+  name           = "ideconn"
+  region         = var.gcp_region
+  #network       = google_compute_network.dev_network.name
+  network        = var.sva_network 
+  #ip_cidr_range = "10.8.0.0/28"
+  ip_cidr_range  = var.sva_subnet_cidr 
+
+  # Note: valid options: f1-micro, e2-micro, e2-standard-4
+  machine_type = var.sva_connector_machine_type
+
+  depends_on = [
+    # google_project_service.vpcaccess-api, google_compute_network.dev_network
+    google_project_service.vpcaccess-api
+  ]
+}
+


### PR DESCRIPTION
Reverts CloudVLab/terraform-lab-foundation#434

I am not sure if this PR is quite right - the `google beta` provider is actually needed in many cases.

Also, as per https://github.com/hashicorp/terraform-provider-google/issues/21493, I think the underlying issue is fixed.