### PR TITLE
update: fix default image_family

### DIFF
--- a/solutions/la_generative_ai/stable/variables.tf
+++ b/solutions/la_generative_ai/stable/variables.tf
@@ -45,7 +45,7 @@ variable "sme_image_project" {
 variable "sme_image_family" {
   type        = string
   description = "Machine image family"
-  default     = "tf-ent-2-11-cu113-notebooks-debian-11-py310"
+  default     = "tf-ent-2-17-cu123-notebooks-debian-11-py310"
 }
 
 variable "sme_git_repo" {


### PR DESCRIPTION
Bug Fix: https://buganizer.corp.google.com/issues/423563190

- [x] updated image_family to point to updated version of tf enterprise `tf-ent-2-17-cu123-notebooks-debian-11-py310`
