### PR TITLE
Gen AI Modules: Fix Output for local module reference 

### DIFF
--- a/solutions/gen_ai_models/dev/outputs.tf
+++ b/solutions/gen_ai_models/dev/outputs.tf
@@ -17,5 +17,5 @@ output "gemini_flash" {
 
 output "gemini_embedding" {
   description = "Embedding model details."
-  value       = local.models.embedding
+  value       = local.models.gemini_embedding
 }

--- a/solutions/gen_ai_models/stable/outputs.tf
+++ b/solutions/gen_ai_models/stable/outputs.tf
@@ -17,5 +17,5 @@ output "gemini_flash" {
 
 output "gemini_embedding" {
   description = "Embedding model details."
-  value       = local.models.embedding
+  value       = local.models.gemini_embedding
 }


### PR DESCRIPTION
- Fix module output reference to use `gemini_embedding` in stable/dev channels