### PR TITLE
Update Gemini preview models

### DIFF
--- a/solutions/gen_ai_models/preview/main.tf
+++ b/solutions/gen_ai_models/preview/main.tf
@@ -14,20 +14,20 @@ locals {
       "model_name" = "Gemini 3 Flash"
     },
     "gemini_flash_lite" = {
-      "model_id"   = "gemini-2.5-flash-lite"
-      "model_name" = "Gemini 2.5 Flash-Lite"
+      "model_id"   = "gemini-3.1-flash-lite-preview"
+      "model_name" = "Gemini 3.1 Flash-Lite"
     },
     "gemini_flash_image" = {
       "model_id"   = "gemini-3.1-flash-image-preview"
       "model_name" = "Nano Banana 2"
     },
     "gemini_flash_live" = {
-      "model_id"   = "gemini-live-2.5-flash-native-audio"
-      "model_name" = "Gemini 2.5 Flash Native Audio"
+      "model_id"   = "gemini-2.5-flash-native-audio-preview-12-2025"
+      "model_name" = "Gemini 2.5 Flash Native Audio Preview"
     },
     "gemini_embedding" = {
-      "model_id"   = "gemini-embedding-001"
-      "model_name" = "Gemini Embedding 001"
+      "model_id"   = "gemini-embedding-2-preview"
+      "model_name" = "Gemini Embedding 2"
     },
     "multimodal_embedding" = {
       "model_id"   = "multimodalembedding@001"


### PR DESCRIPTION
Bumps the preview channel models mapping in main.tf to their latest recommended preview versions according to the official deprecation schedules.