### PR TITLE
feat(gen_ai_models): align channels with latest Gemini models and dynamically generate README

### DIFF
--- a/solutions/gen_ai_models/README.md
+++ b/solutions/gen_ai_models/README.md
@@ -10,19 +10,20 @@ This module provisions Generative AI models on Google Cloud.
 
 ## Accessing Output Values
 
-| Field | Description | Channel |
-|---|---|---|
-| `models` | A map of all available Generative AI models. | Stable, Preview |
-| `gemini_pro` | Gemini Pro model details. | Stable, Preview |
-| `gemini_pro_image` | Gemini Pro Image (Nano Banana 2) model details. | Preview |
-| `gemini_flash` | Gemini Flash model details. | Stable |
-| `gemini_flash_lite` | Gemini Flash Lite model details. | Stable |
-| `gemini_flash_image` | Gemini Flash Image (Nano Banana) model details. | Stable |
-| `gemini_flash_live` | Gemini Flash Native Audio model details. | Stable |
-| `gemini_embedding` | Gemini Embedding model details. | Stable |
-| `multimodal_embedding` | Embeddings for Multimodal model details. | Stable |
-| `text_embedding` | Text Embedding model details. | Stable |
+This table compares the configured `model_id` and `model_name` across the stable, preview, and development channels.
 
+| Output Field | Description | Stable Channel | Preview Channel | Dev Channel |
+|---|---|---|---|---|
+| `models` | A map of all available Generative AI models. | *Full Map* | *Full Map* | *Full Map* |
+| `gemini_pro` | Gemini Pro model details. | `gemini-2.5-pro`<br>_(Gemini 2.5 Pro)_ | `gemini-3.1-pro-preview`<br>_(Gemini 3.1 Pro)_ | `gemini-3.1-pro-preview`<br>_(Gemini 3.1 Pro)_ |
+| `gemini_pro_image` | Gemini Pro Image model details. | `gemini-3-pro-image`<br>_(Nano Banana Pro)_ | `gemini-3-pro-image`<br>_(Nano Banana Pro)_ | `gemini-3-pro-image`<br>_(Nano Banana Pro)_ |
+| `gemini_flash` | Gemini Flash model details. | `gemini-2.5-flash`<br>_(Gemini 2.5 Flash)_ | `gemini-3.5-flash`<br>_(Gemini 3.5 Flash)_ | `gemini-3.5-flash`<br>_(Gemini 3.5 Flash)_ |
+| `gemini_flash_lite` | Gemini Flash Lite model details. | `gemini-2.5-flash-lite`<br>_(Gemini 2.5 Flash-Lite)_ | `gemini-3.1-flash-lite`<br>_(Gemini 3.1 Flash-Lite)_ | `gemini-3.1-flash-lite`<br>_(Gemini 3.1 Flash-Lite)_ |
+| `gemini_flash_image` | Gemini Flash Image model details. | `gemini-2.5-flash-image`<br>_(Gemini 2.5 Flash Image)_ | `gemini-3.1-flash-image`<br>_(Nano Banana 2)_ | `gemini-3.1-flash-image`<br>_(Nano Banana 2)_ |
+| `gemini_flash_live` | Gemini Flash Native Audio model details. | `gemini-live-2.5-flash-native-audio`<br>_(Gemini 2.5 Flash Native Audio)_ | `gemini-3.1-flash-live-preview`<br>_(Gemini 3.1 Flash Live)_ | `gemini-3.1-flash-live-preview`<br>_(Gemini 3.1 Flash Live)_ |
+| `gemini_embedding` | Gemini Embedding model details. | `gemini-embedding-001`<br>_(Gemini Embedding 001)_ | `gemini-embedding-001`<br>_(Gemini Embedding)_ | `gemini-embedding-001`<br>_(Gemini Embedding)_ |
+| `multimodal_embedding` | Embeddings for Multimodal model details. | `multimodalembedding@001`<br>_(Embeddings for Multimodal)_ | `multimodalembedding@001`<br>_(Embeddings for Multimodal)_ | `multimodalembedding@001`<br>_(Embeddings for Multimodal)_ |
+| `text_embedding` | Text Embedding model details. | `text-embedding-005`<br>_(Text Embedding 005)_ | `text-embedding-005`<br>_(Text Embedding 005)_ | `text-embedding-005`<br>_(Text Embedding 005)_ |
 ## Adding a Commit
 
 Commits to the repository will initiate the automated QA process.

--- a/solutions/gen_ai_models/dev/main.tf
+++ b/solutions/gen_ai_models/dev/main.tf
@@ -2,28 +2,32 @@
 locals {
   models = {
     "gemini_pro" = {
-      "model_id"   = "gemini-2.5-pro"
-      "model_name" = "Gemini 2.5 Pro"
+      "model_id"   = "gemini-3.1-pro-preview"
+      "model_name" = "Gemini 3.1 Pro"
+    },
+    "gemini_pro_image" = {
+      "model_id"   = "gemini-3-pro-image"
+      "model_name" = "Nano Banana Pro"
     },
     "gemini_flash" = {
-      "model_id"   = "gemini-2.5-flash"
-      "model_name" = "Gemini 2.5 Flash"
+      "model_id"   = "gemini-3.5-flash"
+      "model_name" = "Gemini 3.5 Flash"
     },
     "gemini_flash_lite" = {
-      "model_id"   = "gemini-2.5-flash-lite"
-      "model_name" = "Gemini 2.5 Flash-Lite"
+      "model_id"   = "gemini-3.1-flash-lite"
+      "model_name" = "Gemini 3.1 Flash-Lite"
     },
     "gemini_flash_image" = {
-      "model_id"   = "gemini-2.5-flash-image"
-      "model_name" = "Gemini 2.5 Flash Image"
+      "model_id"   = "gemini-3.1-flash-image"
+      "model_name" = "Nano Banana 2"
     },
     "gemini_flash_live" = {
-      "model_id"   = "gemini-live-2.5-flash-native-audio"
-      "model_name" = "Gemini 2.5 Flash Native Audio"
+      "model_id"   = "gemini-3.1-flash-live-preview"
+      "model_name" = "Gemini 3.1 Flash Live"
     },
     "gemini_embedding" = {
       "model_id"   = "gemini-embedding-001"
-      "model_name" = "Gemini Embedding 001"
+      "model_name" = "Gemini Embedding"
     },
     "multimodal_embedding" = {
       "model_id"   = "multimodalembedding@001"

--- a/solutions/gen_ai_models/dev/outputs.tf
+++ b/solutions/gen_ai_models/dev/outputs.tf
@@ -1,4 +1,4 @@
-# solutions/gen_ai_models/outputs.tf
+# solutions/gen_ai_models/dev/outputs.tf
 
 output "models" {
   description = "A map of all available Generative AI models."
@@ -8,6 +8,11 @@ output "models" {
 output "gemini_pro" {
   description = "Gemini Pro model details."
   value       = local.models.gemini_pro
+}
+
+output "gemini_pro_image" {
+  description = "Gemini Pro Image model details."
+  value       = local.models.gemini_pro_image
 }
 
 output "gemini_flash" {

--- a/solutions/gen_ai_models/preview/main.tf
+++ b/solutions/gen_ai_models/preview/main.tf
@@ -6,7 +6,7 @@ locals {
       "model_name" = "Gemini 3.1 Pro"
     },
     "gemini_pro_image" = {
-      "model_id"   = "gemini-3-pro-image-preview"
+      "model_id"   = "gemini-3-pro-image"
       "model_name" = "Nano Banana Pro"
     },
     "gemini_flash" = {
@@ -18,12 +18,12 @@ locals {
       "model_name" = "Gemini 3.1 Flash-Lite"
     },
     "gemini_flash_image" = {
-      "model_id"   = "gemini-3.1-flash-image-preview"
+      "model_id"   = "gemini-3.1-flash-image"
       "model_name" = "Nano Banana 2"
     },
     "gemini_flash_live" = {
-      "model_id"   = "gemini-2.5-flash-native-audio-preview-12-2025"
-      "model_name" = "Gemini 2.5 Flash Native Audio Preview"
+      "model_id"   = "gemini-3.1-flash-live-preview"
+      "model_name" = "Gemini 3.1 Flash Live"
     },
     "gemini_embedding" = {
       "model_id"   = "gemini-embedding-001"

--- a/solutions/gen_ai_models/stable/main.tf
+++ b/solutions/gen_ai_models/stable/main.tf
@@ -5,6 +5,10 @@ locals {
       "model_id"   = "gemini-2.5-pro"
       "model_name" = "Gemini 2.5 Pro"
     },
+    "gemini_pro_image" = {
+      "model_id"   = "gemini-3-pro-image"
+      "model_name" = "Nano Banana Pro"
+    },
     "gemini_flash" = {
       "model_id"   = "gemini-2.5-flash"
       "model_name" = "Gemini 2.5 Flash"

--- a/solutions/gen_ai_models/stable/outputs.tf
+++ b/solutions/gen_ai_models/stable/outputs.tf
@@ -10,6 +10,11 @@ output "gemini_pro" {
   value       = local.models.gemini_pro
 }
 
+output "gemini_pro_image" {
+  description = "Gemini Pro Image model details."
+  value       = local.models.gemini_pro_image
+}
+
 output "gemini_flash" {
   description = "Gemini Flash model details."
   value       = local.models.gemini_flash

--- a/solutions/gen_ai_models/update_readme.py
+++ b/solutions/gen_ai_models/update_readme.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+import os
+import re
+
+def parse_tf_models(file_path):
+    models = {}
+    if not os.path.exists(file_path):
+        return models
+    
+    with open(file_path, 'r') as f:
+        content = f.read()
+    
+    block_pattern = re.compile(r'"([^"]+)"\s*=\s*\{([^}]+)\}', re.DOTALL)
+    kv_pattern = re.compile(r'"([^"]+)"\s*=\s*"([^"]+)"')
+    
+    for block_match in block_pattern.finditer(content):
+        key = block_match.group(1)
+        inner_content = block_match.group(2)
+        
+        model_data = {}
+        for kv_match in kv_pattern.finditer(inner_content):
+            model_data[kv_match.group(1)] = kv_match.group(2)
+        
+        if model_data:
+            models[key] = model_data
+            
+    return models
+
+def get_model_display(model_data):
+    if not model_data:
+        return "*Not Available*"
+    model_id = model_data.get("model_id", "")
+    model_name = model_data.get("model_name", "")
+    return f"`{model_id}`<br>_({model_name})_"
+
+def main():
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    
+    stable_path = os.path.join(base_dir, "stable", "main.tf")
+    preview_path = os.path.join(base_dir, "preview", "main.tf")
+    dev_path = os.path.join(base_dir, "dev", "main.tf")
+    
+    stable_models = parse_tf_models(stable_path)
+    preview_models = parse_tf_models(preview_path)
+    dev_models = parse_tf_models(dev_path)
+    
+    # Collect all unique keys in a deterministic order
+    keys_order = [
+        "models",
+        "gemini_pro",
+        "gemini_pro_image",
+        "gemini_flash",
+        "gemini_flash_lite",
+        "gemini_flash_image",
+        "gemini_flash_live",
+        "gemini_embedding",
+        "multimodal_embedding",
+        "text_embedding"
+    ]
+    
+    all_keys = list(set(list(stable_models.keys()) + list(preview_models.keys()) + list(dev_models.keys())))
+    # Sort by keys_order first, then alphabetically for any others
+    all_keys.sort(key=lambda k: keys_order.index(k) if k in keys_order else len(keys_order) + all_keys.index(k))
+    # Ensure 'models' is always the first element in the table
+    all_keys = ["models"] + all_keys
+    
+    # Key descriptions
+    descriptions = {
+        "models": "A map of all available Generative AI models.",
+        "gemini_pro": "Gemini Pro model details.",
+        "gemini_pro_image": "Gemini Pro Image model details.",
+        "gemini_flash": "Gemini Flash model details.",
+        "gemini_flash_lite": "Gemini Flash Lite model details.",
+        "gemini_flash_image": "Gemini Flash Image model details.",
+        "gemini_flash_live": "Gemini Flash Native Audio model details.",
+        "gemini_embedding": "Gemini Embedding model details.",
+        "multimodal_embedding": "Embeddings for Multimodal model details.",
+        "text_embedding": "Text Embedding model details."
+    }
+    
+    # Generate markdown table
+    lines = [
+        "## Accessing Output Values",
+        "",
+        "This table compares the configured `model_id` and `model_name` across the stable, preview, and development channels.",
+        "",
+        "| Output Field | Description | Stable Channel | Preview Channel | Dev Channel |",
+        "|---|---|---|---|---|"
+    ]
+    
+    for key in all_keys:
+        if key == "models":
+            # The 'models' key itself is the map containing everything, so display special description
+            lines.append(f"| `models` | {descriptions.get(key, '')} | *Full Map* | *Full Map* | *Full Map* |")
+            continue
+            
+        desc = descriptions.get(key, f"{key.replace('_', ' ').title()} details.")
+        stable_disp = get_model_display(stable_models.get(key))
+        preview_disp = get_model_display(preview_models.get(key))
+        dev_disp = get_model_display(dev_models.get(key))
+        
+        lines.append(f"| `{key}` | {desc} | {stable_disp} | {preview_disp} | {dev_disp} |")
+        
+    lines.append("") # Add a trailing newline
+    table_md = "\n".join(lines)
+    
+    readme_path = os.path.join(base_dir, "README.md")
+    with open(readme_path, "r") as f:
+        readme_content = f.read()
+        
+    # Replace the section between "## Accessing Output Values" and "## Adding a Commit"
+    pattern = re.compile(r"## Accessing Output Values\n.*?\n(?=## Adding a Commit)", re.DOTALL)
+    
+    if pattern.search(readme_content):
+        new_content = pattern.sub(table_md, readme_content)
+        with open(readme_path, "w") as f:
+            f.write(new_content)
+        print("README.md table updated successfully!")
+    else:
+        print("Could not find correct placeholder headers in README.md to update.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Aligns the stable, preview, and dev channels of the `gen_ai_models` module with the latest Gemini model versions released as of May 28, 2026 (including `gemini-3-pro-image` and `gemini-3.1-flash-image`).

### Changes:
1. **Stable Channel**:
   - Added `gemini_pro_image` configured with GA `gemini-3-pro-image` named `Nano Banana Pro`.
2. **Preview/Dev Channels**:
   - Configured `gemini_pro` to use the latest `"gemini-3.1-pro-preview"`.
   - Configured `gemini_pro_image` to use `"gemini-3-pro-image"` (GA today!).
   - Configured `gemini_flash_image` to use `"gemini-3.1-flash-image"` (GA today!).
   - Configured `gemini_flash_live` to use the recommended `"gemini-3.1-flash-live-preview"`.
3. **Automation**:
   - Added a dynamic documentation script `update_readme.py` that parses model files and regenerates a side-by-side comparison table in `README.md` automatically.