### PR TITLE
Create os_images adapted from gen_ai_models

### DIFF
--- a/solutions/os_images/README.md
+++ b/solutions/os_images/README.md
@@ -10,12 +10,12 @@ This module provisions OS images on Google Cloud.
 
 ## Accessing Output Values
 
-This table compares the configured `image_id_short` and `image_name_short` across the stable, preview, and development channels.
+This table compares the configured `image_id_short`, `image_name_short`, `image_id_long`, and `image_name_long` across the stable, preview, and development channels.
 
 | Output Field | Description | Stable Channel | Preview Channel | Dev Channel |
 |---|---|---|---|---|
 | `os_images` | A map of all configured OS images. | *Full Map* | *Full Map* | *Full Map* |
-| `debian` | Debian OS image details. | `debian-12`<br>_(Debian 12)_ | `debian-13`<br>_(Debian 13)_ | `debian-13`<br>_(Debian 13)_ |
+| `debian` | Debian OS image details. | `debian-12`<br>_(Debian 12)_<br><br>`debian-12-bookworm`<br>_(Debian GNU/Linux 12 (bookworm))_ | `debian-13`<br>_(Debian 13)_<br><br>`debian-13-trixie`<br>_(Debian GNU/Linux 13 (trixie))_ | `debian-13`<br>_(Debian 13)_<br><br>`debian-13-trixie`<br>_(Debian GNU/Linux 13 (trixie))_ |
 ## Adding a Commit
 
 Commits to the repository will initiate the automated QA process.

--- a/solutions/os_images/README.md
+++ b/solutions/os_images/README.md
@@ -1,0 +1,27 @@
+# Terraform: OS Images
+
+| Channel   | Status                          |
+|---        |---                              |
+| Dev       | Active Development & Testing    |
+| Preview   | Preview Release                 |
+| Stable    | Production Ready (Live Labs)    |
+
+This module provisions OS images on Google Cloud.
+
+## Accessing Output Values
+
+This table compares the configured `image_id_short` and `image_name_short` across the stable, preview, and development channels.
+
+| Output Field | Description | Stable Channel | Preview Channel | Dev Channel |
+|---|---|---|---|---|
+| `os_images` | A map of all configured OS images. | *Full Map* | *Full Map* | *Full Map* |
+| `debian` | Debian OS image details. | `debian-12`<br>_(Debian 12)_ | `debian-13`<br>_(Debian 13)_ | `debian-13`<br>_(Debian 13)_ |
+## Adding a Commit
+
+Commits to the repository will initiate the automated QA process.
+
+It is highly recommended that modules are tested locally before making a commit.
+
+## Request a Pull Request
+
+__DO NOT__ raise a PR on code that does not pass integration tests.

--- a/solutions/os_images/cloudbuild.yaml
+++ b/solutions/os_images/cloudbuild.yaml
@@ -1,0 +1,21 @@
+steps:
+- name: 'hashicorp/terraform:${_PROVIDER_VER}'
+  args: ['init']
+  id: init-terraform
+  dir: '${_TERRAFORM_DIR}' 
+- name: 'hashicorp/terraform:${_PROVIDER_VER}'
+  args: ['validate']
+  id: validate-terraform
+  dir: '${_TERRAFORM_DIR}' 
+- name: 'hashicorp/terraform:${_PROVIDER_VER}'
+  args: ['apply', '-auto-approve']
+  id: apply-terraform
+  dir: '${_TERRAFORM_DIR}' 
+- name: 'hashicorp/terraform:${_PROVIDER_VER}'
+  args: ['destroy', '-auto-approve']
+  id: destroy-terraform
+  dir: '${_TERRAFORM_DIR}' 
+substitutions:  
+  _PROVIDER_VER: 1.12.1
+  _TERRAFORM_DIR: solutions/os_images/stable
+tags: ['terraform-lab-foundation', 'os-images']

--- a/solutions/os_images/dev/main.tf
+++ b/solutions/os_images/dev/main.tf
@@ -1,0 +1,11 @@
+# solutions/os_images/dev/main.tf
+locals {
+  os_images = {
+    "debian" = {
+      "image_id_short"   = "debian-13"
+      "image_name_short" = "Debian 13" 
+      "image_id_long"    = "debian-13-trixie"
+      "image_name_long"  = "Debian GNU/Linux 13 (trixie)" 
+    }
+  }
+}

--- a/solutions/os_images/dev/outputs.tf
+++ b/solutions/os_images/dev/outputs.tf
@@ -1,0 +1,11 @@
+# solutions/os_images/dev/outputs.tf
+
+output "os_images" {
+  description = "A map of all configured OS images."
+  value       = local.os_images
+}
+
+output "debian" {
+  description = "Debian OS image details."
+  value       = local.os_images.debian
+}

--- a/solutions/os_images/dev/runtime.yaml
+++ b/solutions/os_images/dev/runtime.yaml
@@ -1,0 +1,2 @@
+runtime: terraform
+version: 1.12.1

--- a/solutions/os_images/example/install.sh
+++ b/solutions/os_images/example/install.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+BRANCH="main"
+CHANNEL="STABLE"
+TYPE="solutions"
+MODULE="os_images"
+
+# Set the endpoint for the module
+if [ "$CHANNEL" = "STABLE" ]; then
+  ## STABLE Channel
+  URL="https://storage.googleapis.com/terraform-lab-foundation/"
+  # URL="https://github.com/CloudVLab/terraform-lab-foundation/raw/${BRANCH}"
+else
+  ## DEV/BETA Channel
+  URL="https://github.com/CloudVLab/terraform-lab-foundation/raw/${BRANCH}"
+fi 
+
+DIRECTORY="tf"
+FILE1="main.tf"
+FILE1_URL="${URL}/${TYPE}/${MODULE}/example/main.tf"
+FILE2="outputs.tf"
+FILE2_URL="${URL}/${TYPE}/${MODULE}/example/outputs.tf"
+FILE3="runtime.yaml"
+FILE3_URL="${URL}/${TYPE}/${MODULE}/example/runtime.yaml"
+FILE4="variables.tf"
+FILE4_URL="${URL}/${TYPE}/${MODULE}/example/variables.tf"
+
+# Create TF directory if not present
+if [ ! -d $DIRECTORY ]; then
+  mkdir $DIRECTORY 
+fi
+
+# Download if the file does not exist
+if [ ! -f $DIRECTORY/$FILE1 ]; then
+  curl -L "$FILE1_URL" -o "$DIRECTORY/$FILE1"
+fi 
+
+# Download if the file does not exist
+if [ ! -f $DIRECTORY/$FILE2 ]; then
+  curl -L "$FILE2_URL" -o "$DIRECTORY/$FILE2"
+fi
+
+# Download if the file does not exist
+if [ ! -f $DIRECTORY/$FILE3 ]; then
+  curl -L "$FILE3_URL" -o "$DIRECTORY/$FILE3"
+fi
+
+# Download if the file does not exist
+if [ ! -f $DIRECTORY/$FILE4 ]; then
+  curl -L "$FILE4_URL" -o "$DIRECTORY/$FILE4"
+fi

--- a/solutions/os_images/example/main.tf
+++ b/solutions/os_images/example/main.tf
@@ -1,0 +1,15 @@
+#
+# ------------------ Module Definition 
+#
+
+# Solution: OS Images environment 
+# Local:  solutions/os_images/stable
+# Remote: github//solutions/os_images/stable
+
+module "os_images" {
+  ## NOTE: When changing the `source` parameter
+  ## `terraform init` is required
+
+  ## REMOTE: GitHub (Public) access - working 
+  source = "github.com/CloudVLab/terraform-lab-foundation//solutions/os_images/stable"
+}

--- a/solutions/os_images/example/runtime.yaml
+++ b/solutions/os_images/example/runtime.yaml
@@ -1,0 +1,2 @@
+runtime: terraform
+version: 1.12.1

--- a/solutions/os_images/example/variables.tf
+++ b/solutions/os_images/example/variables.tf
@@ -1,0 +1,11 @@
+variable "gcp_project_id" {
+  type = string
+}
+
+variable "gcp_region" {
+  type = string
+}
+
+variable "gcp_zone" {
+  type = string
+}

--- a/solutions/os_images/preview/main.tf
+++ b/solutions/os_images/preview/main.tf
@@ -1,0 +1,11 @@
+# solutions/os_images/preview/main.tf
+locals {
+  os_images = {
+    "debian" = {
+      "image_id_short"   = "debian-13"
+      "image_name_short" = "Debian 13" 
+      "image_id_long"    = "debian-13-trixie"
+      "image_name_long"  = "Debian GNU/Linux 13 (trixie)" 
+    }
+  }
+}

--- a/solutions/os_images/preview/outputs.tf
+++ b/solutions/os_images/preview/outputs.tf
@@ -1,0 +1,11 @@
+# solutions/os_images/preview/outputs.tf
+
+output "os_images" {
+  description = "A map of all configured OS images."
+  value       = local.os_images
+}
+
+output "debian" {
+  description = "Debian OS image details."
+  value       = local.os_images.debian
+}

--- a/solutions/os_images/preview/runtime.yaml
+++ b/solutions/os_images/preview/runtime.yaml
@@ -1,0 +1,2 @@
+runtime: terraform
+version: 1.12.1

--- a/solutions/os_images/preview/test.tfvars
+++ b/solutions/os_images/preview/test.tfvars
@@ -1,0 +1,3 @@
+gcp_project_id = "qwiklabs-resources"
+gcp_region     = "us-central1"
+gcp_zone       = "us-central1-a"

--- a/solutions/os_images/stable/main.tf
+++ b/solutions/os_images/stable/main.tf
@@ -1,0 +1,11 @@
+# solutions/os_images/stable/main.tf
+locals {
+  os_images = {
+    "debian" = {
+      "image_id_short"   = "debian-12"
+      "image_name_short" = "Debian 12" 
+      "image_id_long"    = "debian-12-bookworm"
+      "image_name_long"  = "Debian GNU/Linux 12 (bookworm)" 
+    }
+  }
+}

--- a/solutions/os_images/stable/outputs.tf
+++ b/solutions/os_images/stable/outputs.tf
@@ -1,0 +1,11 @@
+# solutions/os_images/stable/outputs.tf
+
+output "os_images" {
+  description = "A map of all configured OS images."
+  value       = local.os_images
+}
+
+output "debian" {
+  description = "Debian OS image details."
+  value       = local.os_images.debian
+}

--- a/solutions/os_images/stable/runtime.yaml
+++ b/solutions/os_images/stable/runtime.yaml
@@ -1,0 +1,2 @@
+runtime: terraform
+version: 1.12.1

--- a/solutions/os_images/stable/test.tfvars
+++ b/solutions/os_images/stable/test.tfvars
@@ -1,0 +1,3 @@
+gcp_project_id = "qwiklabs-resources"
+gcp_region     = "us-central1"
+gcp_zone       = "us-central1-a"

--- a/solutions/os_images/update_readme.py
+++ b/solutions/os_images/update_readme.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+import os
+import re
+
+def parse_tf_images(file_path):
+    images = {}
+    if not os.path.exists(file_path):
+        return images
+    
+    with open(file_path, 'r') as f:
+        content = f.read()
+    
+    block_pattern = re.compile(r'"([^"]+)"\s*=\s*\{([^}]+)\}', re.DOTALL)
+    kv_pattern = re.compile(r'"([^"]+)"\s*=\s*"([^"]+)"')
+    
+    for block_match in block_pattern.finditer(content):
+        key = block_match.group(1)
+        inner_content = block_match.group(2)
+        
+        image_data = {}
+        for kv_match in kv_pattern.finditer(inner_content):
+            image_data[kv_match.group(1)] = kv_match.group(2)
+        
+        if image_data:
+            images[key] = image_data
+            
+    return images
+
+def get_image_display(image_data):
+    if not image_data:
+        return "*Not Available*"
+    image_id = image_data.get("image_id_short", "")
+    image_name = image_data.get("image_name_short", "")
+    return f"`{image_id}`<br>_({image_name})_"
+
+def main():
+    base_dir = os.path.dirname(os.path.abspath(__file__))
+    
+    stable_path = os.path.join(base_dir, "stable", "main.tf")
+    preview_path = os.path.join(base_dir, "preview", "main.tf")
+    dev_path = os.path.join(base_dir, "dev", "main.tf")
+    
+    stable_images = parse_tf_images(stable_path)
+    preview_images = parse_tf_images(preview_path)
+    dev_images = parse_tf_images(dev_path)
+    
+    # Collect all unique keys in a deterministic order
+    keys_order = [
+        "os_images",
+        "debian"
+    ]
+    
+    all_keys = list(set(list(stable_images.keys()) + list(preview_images.keys()) + list(dev_images.keys())))
+    # Sort by keys_order first, then alphabetically for any others
+    all_keys.sort(key=lambda k: keys_order.index(k) if k in keys_order else len(keys_order) + all_keys.index(k))
+    # Ensure 'os_images' is always the first element in the table
+    all_keys = ["os_images"] + [k for k in all_keys if k != "os_images"]
+    
+    # Key descriptions
+    descriptions = {
+        "os_images": "A map of all configured OS images.",
+        "debian": "Debian OS image details."
+    }
+    
+    # Generate markdown table
+    lines = [
+        "## Accessing Output Values",
+        "",
+        "This table compares the configured `image_id_short` and `image_name_short` across the stable, preview, and development channels.",
+        "",
+        "| Output Field | Description | Stable Channel | Preview Channel | Dev Channel |",
+        "|---|---|---|---|---|"
+    ]
+    
+    for key in all_keys:
+        if key == "os_images":
+            # The 'os_images' key itself is the map containing everything, so display special description
+            lines.append(f"| `os_images` | {descriptions.get(key, '')} | *Full Map* | *Full Map* | *Full Map* |")
+            continue
+            
+        desc = descriptions.get(key, f"{key.replace('_', ' ').title()} details.")
+        stable_disp = get_image_display(stable_images.get(key))
+        preview_disp = get_image_display(preview_images.get(key))
+        dev_disp = get_image_display(dev_images.get(key))
+        
+        lines.append(f"| `{key}` | {desc} | {stable_disp} | {preview_disp} | {dev_disp} |")
+        
+    lines.append("") # Add a trailing newline
+    table_md = "\n".join(lines)
+    
+    readme_path = os.path.join(base_dir, "README.md")
+    with open(readme_path, "r") as f:
+        readme_content = f.read()
+        
+    # Replace the section between "## Accessing Output Values" and "## Adding a Commit"
+    pattern = re.compile(r"## Accessing Output Values\n.*?\n(?=## Adding a Commit)", re.DOTALL)
+    
+    if pattern.search(readme_content):
+        new_content = pattern.sub(table_md, readme_content)
+        with open(readme_path, "w") as f:
+            f.write(new_content)
+        print("README.md table updated successfully!")
+    else:
+        print("Could not find correct placeholder headers in README.md to update.")
+
+if __name__ == "__main__":
+    main()

--- a/solutions/os_images/update_readme.py
+++ b/solutions/os_images/update_readme.py
@@ -31,7 +31,17 @@ def get_image_display(image_data):
         return "*Not Available*"
     image_id = image_data.get("image_id_short", "")
     image_name = image_data.get("image_name_short", "")
-    return f"`{image_id}`<br>_({image_name})_"
+    image_id_long = image_data.get("image_id_long", "")
+    image_name_long = image_data.get("image_name_long", "")
+    
+    display = ""
+    if image_id and image_name:
+        display += f"`{image_id}`<br>_({image_name})_"
+    if image_id_long and image_name_long:
+        if display:
+            display += "<br><br>"
+        display += f"`{image_id_long}`<br>_({image_name_long})_"
+    return display if display else "*Not Available*"
 
 def main():
     base_dir = os.path.dirname(os.path.abspath(__file__))
@@ -66,7 +76,7 @@ def main():
     lines = [
         "## Accessing Output Values",
         "",
-        "This table compares the configured `image_id_short` and `image_name_short` across the stable, preview, and development channels.",
+        "This table compares the configured `image_id_short`, `image_name_short`, `image_id_long`, and `image_name_long` across the stable, preview, and development channels.",
         "",
         "| Output Field | Description | Stable Channel | Preview Channel | Dev Channel |",
         "|---|---|---|---|---|"


### PR DESCRIPTION
This PR creates os_images directory (adapted from the gen_ai_models directory) to expose a debian object containing the image_id_long, image_name_long, image_id_short, and image_name_short attributes for use in Qwiklabs. 

Example application (after mirroring to Cloud Storage): https://github.com/CloudVLab/gcp-spl-content/pull/34429