### PR TITLE
pdate default GCE machine image to Debian 12

### DIFF
--- a/basics/gce_instance/stable/variables.tf
+++ b/basics/gce_instance/stable/variables.tf
@@ -74,7 +74,7 @@ variable "gce_tags" {
 variable "gce_machine_image" {
   type        = string
   description = "GCE virtual machine image"
-  default     = "debian-cloud/debian-11"
+  default     = "debian-cloud/debian-12"
 }
 
 variable "gce_disk_size" {


### PR DESCRIPTION
- [x] Update default GCE machine image to Debian 12
- Related Buganizer: http://b/556135931