### PR TITLE
Update default GCE machine image to Debian 12

### DIFF
--- a/basics/gce_instance/stable/v1/variables.tf
+++ b/basics/gce_instance/stable/v1/variables.tf
@@ -75,7 +75,7 @@ variable "gce_tags" {
 variable "gce_machine_image" {
   type        = string
   description = "GCE virtual machine image"
-  default     = "debian-cloud/debian-11"
+  default     = "debian-cloud/debian-12"
 }
 
 # Custom properties with defaults 


### PR DESCRIPTION
Update default GCE machine image to Debian 12
Related Buganizer: http://b/556135931