### PR TITLE
fix(ide_cloudshell): use dynamic gcp_region for dev_subnet and dynamic zone for GCE instance

### DIFF
--- a/solutions/ide_cloudshell/dev/variables.tf
+++ b/solutions/ide_cloudshell/dev/variables.tf
@@ -84,8 +84,8 @@ variable "gceInstanceName" {
 # Custom properties with defaults 
 variable "gceInstanceZone" {
   type        = string 
-  description = "Zone to create resources in."
-  default     = "us-central1-f" 
+  description = "Zone to create resources in. If null, defaults to gcp_zone."
+  default     = null 
 }
 
 # Custom properties with defaults 

--- a/solutions/ide_cloudshell/stable/main.tf
+++ b/solutions/ide_cloudshell/stable/main.tf
@@ -15,7 +15,7 @@ resource "google_compute_network" "dev_network" {
 resource "google_compute_subnetwork" "dev_subnet" {
   name          = "dev-subnetwork"
   ip_cidr_range = "10.128.0.0/16"
-  region        = "us-central1"
+  region        = var.gcp_region
   network       = google_compute_network.dev_network.id
 }
 
@@ -300,7 +300,7 @@ resource "google_compute_instance" "default" {
 
   name         = var.gceInstanceName
   machine_type = var.gceMachineType
-  zone         = var.gceInstanceZone
+  zone         = coalesce(var.gceInstanceZone, var.gcp_zone)
 
   tags = var.gceInstanceTags
 

--- a/solutions/ide_cloudshell/stable/variables.tf
+++ b/solutions/ide_cloudshell/stable/variables.tf
@@ -72,8 +72,8 @@ variable "gceInstanceName" {
 # Custom properties with defaults 
 variable "gceInstanceZone" {
   type        = string
-  description = "Zone to create resources in."
-  default     = "us-central1-f"
+  description = "Zone to create resources in. If null, defaults to gcp_zone."
+  default     = null
 }
 
 # Custom properties with defaults 


### PR DESCRIPTION
## Summary
Makes `solutions/ide_cloudshell` fully multi-region and multi-zone capable:
1. Updates `dev_subnet` to use `region = var.gcp_region` (eliminating hardcoded `"us-central1"`).
2. Eliminates hardcoded `"us-central1-f"` default on `gceInstanceZone` and enables it to fallback to `var.gcp_zone`.

## Root Cause
- `dev_subnet` had `region = "us-central1"` hardcoded in `solutions/ide_cloudshell/stable/main.tf` line 18, even though `google_vpc_access_connector` and Cloud Run services dynamically used `var.gcp_region`. When a lab runner was scheduled in another region (e.g. `europe-west1`), the VM failed with: `Invalid value for field 'resource.networkInterfaces[0].subnetwork': 'projects/.../regions/europe-west1/subnetworks/dev-subnetwork'. The referenced subnetwork resource cannot be found.`
- In addition, `gceInstanceZone` defaulted to `"us-central1-f"`, leading to `ZONE_RESOURCE_POOL_EXHAUSTED` stockout errors.

## Changes
- In `solutions/ide_cloudshell/stable/main.tf`:
  - Set `region = var.gcp_region` on `google_compute_subnetwork.dev_subnet`
  - Set `zone = coalesce(var.gceInstanceZone, var.gcp_zone)` on `google_compute_instance.default`
- In `solutions/ide_cloudshell/stable/variables.tf` & `dev/variables.tf`:
  - Set `default = null` for `gceInstanceZone`